### PR TITLE
Improve active-monitor controller installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,9 @@ The sort of HealthChecks one could run with Active-Monitor are:
 # step 1: install argo workflow controller
 kubectl apply -f https://raw.githubusercontent.com/keikoproj/active-monitor/master/deploy/deploy-argo.yaml
 
-# step 2: install active-monitor controller
+# step 2: install active-monitor CRD and start controller
 kubectl apply -f https://raw.githubusercontent.com/keikoproj/active-monitor/master/config/crd/bases/activemonitor.keikoproj.io_healthchecks.yaml
 kubectl apply -f https://raw.githubusercontent.com/keikoproj/active-monitor/master/deploy/deploy-active-monitor.yaml
-
-# step 3: run the controller via docker container (binding a volume and setting envVar for kubeconfig file)
-docker run -v ~/.kube/config:/root/.kube/config -e "KUBECONFIG=/root/.kube/config" keikoproj/active-monitor:latest
 ```
 
 ### Alternate Install - using locally cloned code

--- a/deploy/deploy-active-monitor.yaml
+++ b/deploy/deploy-active-monitor.yaml
@@ -83,8 +83,8 @@ spec:
         name: activemonitor-controller
     spec:
       containers:
-        - name: activemonitor-controller
-          image: activemonitor-controller:latest
+        - name: active-monitor
+          image: keikoproj/active-monitor:latest
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
Fixes issue #15

## Proposed Changes
  - modify deploy yaml to use correct docker hub image name
  - update README by removing now unnecessary step of manually running docker container
  
## Testing Done
  - local testing with fresh `minikube` cluster and another fresh `KIND` cluster