### PR TITLE
make ServiceAcct optional attr of HealthCheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,11 @@ COPY metrics/ metrics/
 COPY store/ store/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o active-monitor-controller main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:latest
 WORKDIR /
-COPY --from=builder /workspace/manager .
-ENTRYPOINT ["/manager"]
+COPY --from=builder /workspace/active-monitor-controller .
+ENTRYPOINT [ "/active-monitor-controller" ]

--- a/api/v1alpha1/healthcheck_types.go
+++ b/api/v1alpha1/healthcheck_types.go
@@ -76,7 +76,7 @@ type ResourceObject struct {
 	// Namespace in which to create this object
 	// defaults to the service account namespace
 	Namespace      string `json:"namespace"`
-	ServiceAccount string `json:"serviceAccount"`
+	ServiceAccount string `json:"serviceAccount,omitempty"`
 	// Source of the K8 resource file(s)
 	Source ArtifactLocation `json:"source"`
 }

--- a/config/crd/bases/activemonitor.keikoproj.io_healthchecks.yaml
+++ b/config/crd/bases/activemonitor.keikoproj.io_healthchecks.yaml
@@ -426,7 +426,6 @@ spec:
                       type: object
                   required:
                   - namespace
-                  - serviceAccount
                   - source
                   type: object
               type: object


### PR DESCRIPTION
Fixes issue #17

## Proposed Changes
  - make ServiceAccount an optional attr for HealthCheck
  - change the name of binary built into docker image, using a more descriptive name which can be used in a deployment's `command` details
  
## Testing Done
  - confirmed that validation errors which occurred previously, do not occur after this change