### PR TITLE
Limit Number of times Remedy/Self-Healing can be run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- 1.13.x
+- 1.15.x
 
 git:
   depth: 1

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ The HealthCheck workflow is run periodically, as defined by `repeatAfterSec` or 
 
 Active-Monitor sets the status of the HealthCheck CR to indicate whether the monitoring check succeeded or failed. If in case the monitoring check failed then the Remedy workflow will execute to fix the issue. Status of Remedy will be updated in the CR. External systems can query these CRs and take appropriate action if they failed.
 
+RemedyRunsLimit parameter allows to configure how many times a remedy should be run. If Remedy action fails for any reason it will stop on further retries. It is an optional parameter. If it is not set Remedyworkflow is triggered whenever HealthCheck workflow fails.
+
+RemedyResetInterval parameter allows resetting remedy after the reset interval time and RemedyWorkflow can be retried again in case monitor workflow fails. If remedy reaches a RemedyRunsLimit it will be reset when HealthCheck passes in any subsequent run before RemedyResetInterval. 
+
 Typical examples of such workflows include tests for basic Kubernetes object creation/deletion, tests for cluster-wide services such as policy engines checks, authentication and authorization checks, etc.
 
 The sort of HealthChecks one could run with Active-Monitor are:

--- a/api/v1alpha1/healthcheck_types.go
+++ b/api/v1alpha1/healthcheck_types.go
@@ -28,12 +28,14 @@ import (
 // HealthCheckSpec defines the desired state of HealthCheck
 // Either RepeatAfterSec or Schedule must be defined for the health check to run
 type HealthCheckSpec struct {
-	RepeatAfterSec int            `json:"repeatAfterSec,omitempty"`
-	Description    string         `json:"description,omitempty"`
-	Workflow       Workflow       `json:"workflow"`
-	Level          string         `json:"level,omitempty"`    // defines if a workflow runs in a Namespace or Cluster level
-	Schedule       ScheduleSpec   `json:"schedule,omitempty"` // Schedule defines schedule rules to run HealthCheck
-	RemedyWorkflow RemedyWorkflow `json:"remedyworkflow,omitempty"`
+	RepeatAfterSec      int            `json:"repeatAfterSec,omitempty"`
+	Description         string         `json:"description,omitempty"`
+	Workflow            Workflow       `json:"workflow"`
+	Level               string         `json:"level,omitempty"`    // defines if a workflow runs in a Namespace or Cluster level
+	Schedule            ScheduleSpec   `json:"schedule,omitempty"` // Schedule defines schedule rules to run HealthCheck
+	RemedyWorkflow      RemedyWorkflow `json:"remedyworkflow,omitempty"`
+	RemedyRunsLimit     int            `json:"remedyRunsLimit,omitempty"`
+	RemedyResetInterval int            `json:"remedyResetInterval,omitempty"`
 }
 
 // HealthCheckStatus defines the observed state of HealthCheck

--- a/config/crd/bases/activemonitor.keikoproj.io_healthchecks.yaml
+++ b/config/crd/bases/activemonitor.keikoproj.io_healthchecks.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: healthchecks.activemonitor.keikoproj.io
 spec:
@@ -62,6 +62,10 @@ spec:
               type: string
             level:
               type: string
+            remedyResetInterval:
+              type: integer
+            remedyRunsLimit:
+              type: integer
             remedyworkflow:
               description: Workflow struct describes a Remedy workflow
               properties:

--- a/controllers/healthcheck_controller.go
+++ b/controllers/healthcheck_controller.go
@@ -114,6 +114,7 @@ func (r *HealthCheckReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 	ctx := context.Background()
 	log := r.Log.WithValues(hcKind, req.NamespacedName)
 	log.Info("Starting HealthCheck reconcile for ...")
+
 	// initialize timers map if not already done
 	if r.RepeatTimersByName == nil {
 		r.RepeatTimersByName = make(map[string]*time.Timer)
@@ -363,7 +364,7 @@ func (r *HealthCheckReconciler) deleteRBACForWorkflow(log logr.Logger, hc *activ
 			log.Error(err, "Error creating ClusterRoleBinding for the workflow")
 			return err
 		}
-		log.Info("Successfully Created", "ClusterRoleBinding", amclusterRoleRemedyBinding)
+		log.Info("Successfully Deleted", "ClusterRoleBinding", amclusterRoleRemedyBinding)
 
 	} else if level == "namespace" {
 
@@ -516,6 +517,17 @@ func (r *HealthCheckReconciler) watchWorkflowReschedule(ctx context.Context, req
 				metrics.MonitorRuntime.With(prometheus.Labels{"healthcheck_name": hc.GetName(), "workflow": healthcheck}).Set(now.Time.Sub(then.Time).Seconds())
 				metrics.MonitorStartedTime.With(prometheus.Labels{"healthcheck_name": hc.GetName(), "workflow": healthcheck}).Set(float64(then.Unix()))
 				metrics.MonitorFinishedTime.With(prometheus.Labels{"healthcheck_name": hc.GetName(), "workflow": healthcheck}).Set(float64(hc.Status.FinishedAt.Unix()))
+				if !hc.Spec.RemedyWorkflow.IsEmpty() && hc.Status.RemedyTotalRuns >= 1 {
+					// HealthCheck Passed so remedy values are reset
+					hc.Status.RemedyTotalRuns = 0
+					hc.Status.RemedyFinishedAt = nil
+					hc.Status.RemedyStartedAt = nil
+					hc.Status.RemedyFailedCount = 0
+					hc.Status.RemedySuccessCount = 0
+					hc.Status.RemedyLastFailedAt = nil
+					hc.Status.RemedyStatus = "HealthCheck Passed so Remedy is reset"
+					log.Info("HealthCheck passed so Remedy is reset", "RemedyTotalRuns:", hc.Status.RemedyTotalRuns, "RemedySuccessCount", hc.Status.RemedySuccessCount, "RemedyFailedCount", hc.Status.RemedyFailedCount)
+				}
 				break
 			} else if status["phase"] == failStr {
 				hc.Status.Status = failStr
@@ -529,11 +541,46 @@ func (r *HealthCheckReconciler) watchWorkflowReschedule(ctx context.Context, req
 				metrics.MonitorError.With(prometheus.Labels{"healthcheck_name": hc.GetName(), "workflow": healthcheck}).Inc()
 				metrics.MonitorStartedTime.With(prometheus.Labels{"healthcheck_name": hc.GetName(), "workflow": healthcheck}).Set(float64(then.Unix()))
 				metrics.MonitorFinishedTime.With(prometheus.Labels{"healthcheck_name": hc.GetName(), "workflow": healthcheck}).Set(float64(now.Time.Unix()))
+				log.Info("Remedy values:", "RemedyTotalRuns:", hc.Status.RemedyTotalRuns)
 				if !hc.Spec.RemedyWorkflow.IsEmpty() {
-					err := r.processRemedyWorkflow(ctx, log, wfNamespace, hc)
-					if err != nil {
-						log.Error(err, "Error  executing RemedyWorkflow")
-						return err
+					log.Info("RemedyWorkflow not empty:")
+					if hc.Spec.RemedyRunsLimit != 0 && hc.Spec.RemedyResetInterval != 0 {
+						log.Info("RemedyRunsLimit and  RemedyResetInterval values are", "RemedyRunsLimit", hc.Spec.RemedyRunsLimit, "RemedyResetInterval", hc.Spec.RemedyResetInterval)
+						if hc.Spec.RemedyRunsLimit > hc.Status.RemedyTotalRuns {
+							log.Info("RemedyRunsLimit is greater than  RemedyTotalRuns", "RemedyRunsLimit", hc.Spec.RemedyRunsLimit, "RemedyTotalRuns", hc.Status.RemedyTotalRuns)
+							err := r.processRemedyWorkflow(ctx, log, wfNamespace, hc)
+							if err != nil {
+								log.Error(err, "Error  executing RemedyWorkflow")
+								return err
+							}
+						} else {
+							remedylastruntime := int(now.Time.Sub(hc.Status.RemedyFinishedAt.Time).Seconds())
+							log.Info("Remedy interval from last time run:", "intervalTime:", remedylastruntime)
+							if hc.Spec.RemedyResetInterval >= remedylastruntime {
+								log.Info("skipping remedy as the remedy limit criteria is met. Remedy will be run after reset interval")
+							} else {
+								hc.Status.RemedyTotalRuns = 0
+								hc.Status.RemedyFinishedAt = nil
+								hc.Status.RemedyStartedAt = nil
+								hc.Status.RemedyFailedCount = 0
+								hc.Status.RemedySuccessCount = 0
+								hc.Status.RemedyLastFailedAt = nil
+								hc.Status.RemedyStatus = "RemedyResetInterval elapsed so Remedy is reset"
+								log.Info("RemedyResetInterval elapsed so Remedy is reset", "RemedyTotalRuns:", hc.Status.RemedyTotalRuns, "RemedySuccessCount", hc.Status.RemedySuccessCount, "RemedyFailedCount", hc.Status.RemedyFailedCount)
+								err := r.processRemedyWorkflow(ctx, log, wfNamespace, hc)
+								if err != nil {
+									log.Error(err, "Error  executing RemedyWorkflow")
+									return err
+								}
+							}
+						}
+					} else {
+						log.Info("RemedyRunsLimit and  RemedyResetInterval are not set")
+						err := r.processRemedyWorkflow(ctx, log, wfNamespace, hc)
+						if err != nil {
+							log.Error(err, "Error  executing RemedyWorkflow")
+							return err
+						}
 					}
 				}
 				break
@@ -837,13 +884,12 @@ func (r *HealthCheckReconciler) parseRemedyWorkflowFromHealthcheck(log logr.Logg
 	// PodGC describes how to delete completed pods as they complete
 	type PodGC struct {
 		// Strategy is the strategy to use. One of "OnPodCompletion", "OnPodSuccess", "OnWorkflowCompletion", "OnWorkflowSuccess"
-		Strategy      PodGCStrategy `json:"strategy,omitempty" protobuf:"bytes,1,opt,name=strategy,casttype=PodGCStrategy"`
+		Strategy PodGCStrategy `json:"strategy,omitempty" protobuf:"bytes,1,opt,name=strategy,casttype=PodGCStrategy"`
 	}
 	pgc := PodGC{
 		Strategy: PodGCOnPodCompletion,
 	}
 	if podGC := data["spec"].(map[string]interface{})["podGC"]; podGC == nil {
-		log.Info("PodGC is nil")
 		data["spec"].(map[string]interface{})["podGC"] = &pgc
 	}
 	// make sure workflows by default get cleaned up

--- a/examples/Remedy_Examples/inlineMemoryRemedy_limit.yaml
+++ b/examples/Remedy_Examples/inlineMemoryRemedy_limit.yaml
@@ -1,0 +1,57 @@
+apiVersion: activemonitor.keikoproj.io/v1alpha1
+kind: HealthCheck
+metadata:
+  generateName: fail-healthcheck-
+  namespace: health
+spec:
+  repeatAfterSec: 30 # duration in seconds
+  level: cluster
+  remedyRunsLimit: 2
+  remedyResetInterval: 300
+  workflow:
+    generateName: randomfail-workflow-
+    resource:
+      namespace: health # workflow will be submitted in this ns
+      serviceAccount: activemonitor-controller-sa # workflow will be submitted using this
+      source:
+        inline: |
+          apiVersion: argoproj.io/v1alpha1
+          kind: Workflow
+          metadata:
+            labels:
+              workflows.argoproj.io/controller-instanceid: activemonitor-workflows
+          spec:
+            ttlSecondsAfterFinished: 60
+            podGC:
+              strategy: OnWorkflowSuccess
+            entrypoint: start
+            templates:
+            - name: start
+              container:
+                image: docker/whalesay:latest
+                command: [/bin/bash, -c]
+                args: ["echo 'Running command';P=(1 0); exit ${P[RANDOM%2]};"]
+  remedyworkflow:
+    generateName: remedy-test-
+    resource:
+      namespace: health # workflow will be submitted in this ns
+      serviceAccount: activemonitor-remedy-sa # workflow will be submitted using this acct
+      source:
+        inline: |
+          apiVersion: argoproj.io/v1alpha1
+          kind: Workflow
+          metadata:
+            labels:
+              workflows.argoproj.io/controller-instanceid: activemonitor-workflows
+            generateName: hello-world-
+          spec:
+            entrypoint: whalesay
+            templates:
+              -
+                container:
+                  args:
+                    - "hello world"
+                  command:
+                    - cowsay
+                  image: "docker/whalesay:latest"
+                name: whalesay

--- a/examples/bdd/inlineMemoryRemedyUnitTest.yaml
+++ b/examples/bdd/inlineMemoryRemedyUnitTest.yaml
@@ -7,6 +7,8 @@ metadata:
 spec:
   repeatAfterSec: 5 # duration in seconds
   level: cluster
+  remedyRunsLimit: 2
+  remedyResetInterval: 300
   workflow:
     generateName: fail-workflow-
     resource:


### PR DESCRIPTION
Signed-off-by: Ravi Hari <ravireliable@gmail.com>

Fixes issue #69 

## Proposed Changes
  - Limit Number of times Remedy/Self-Healing can be run

## Testing Done
  - unit tests:
```
make test                                                                                                                                  rhari@INTUL18b1b859a
/Users/rhari/go/bin/controller-gen object:headerFile=./hack/boilerplate.go.txt paths=./api/...
go fmt ./...
go vet ./...
/Users/rhari/go/bin/controller-gen "crd:trivialVersions=true" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
go test ./api/... ./controllers/... ./metrics/... ./store/... -coverprofile coverage.txt
ok      github.com/keikoproj/active-monitor/api/v1alpha1        5.865s  coverage: 0.8% of statements
ok      github.com/keikoproj/active-monitor/controllers 30.780s coverage: 71.3% of statements
ok      github.com/keikoproj/active-monitor/metrics     1.058s  coverage: 81.8% of statements
?       github.com/keikoproj/active-monitor/store       [no test files]
```

```
~/(limit-remedy*) » kh create -f inlineMemoryRemedy_limit.yaml                                                          
healthcheck.activemonitor.keikoproj.io/fail-healthcheck-xk8d8 created
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get po                                                                                           
NAME                                   READY   STATUS              RESTARTS   AGE
argo-ui-596d785685-vzsg5               1/1     Running             8          17d
randomfail-workflow-qzxkd              0/2     ContainerCreating   0          5s
workflow-controller-689f886b74-qn78p   1/1     Running             5          7d12h
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get wf                                                                                           
NAME                        STATUS      AGE
randomfail-workflow-qzxkd   Succeeded   12s
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get hc                                                                                           
NAME                     LATEST STATUS   SUCCESS CNT     FAIL CNT   REMEDY SUCCESS CNT     REMEDY FAIL CNT   AGE
fail-healthcheck-xk8d8   Succeeded       1                                                                   22s
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get po                                                                                           
NAME                                   READY   STATUS      RESTARTS   AGE
argo-ui-596d785685-vzsg5               1/1     Running     8          17d
randomfail-workflow-5hnwj              0/2     Completed   0          11s
workflow-controller-689f886b74-qn78p   1/1     Running     5          7d12h
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get wf                                                                                           
NAME                        STATUS      AGE
randomfail-workflow-5hnwj   Succeeded   13s
randomfail-workflow-qzxkd   Succeeded   58s
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get hc                                                                                           
NAME                     LATEST STATUS   SUCCESS CNT     FAIL CNT   REMEDY SUCCESS CNT     REMEDY FAIL CNT   AGE
fail-healthcheck-xk8d8   Succeeded       2                                                                   64s
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get wf                                                                                           
NAME                        STATUS      AGE
randomfail-workflow-5hnwj   Succeeded   65s
randomfail-workflow-pfnmf   Succeeded   20s
randomfail-workflow-qzxkd   Succeeded   110s
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get hc                                                                                           
NAME                     LATEST STATUS   SUCCESS CNT     FAIL CNT   REMEDY SUCCESS CNT     REMEDY FAIL CNT   AGE
fail-healthcheck-xk8d8   Succeeded       3                                                                   113s
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get wf                                                                                           
NAME                        STATUS      AGE
randomfail-workflow-pfnmf   Succeeded   50s
randomfail-workflow-r8p5w   Running     5s
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get po                                                                                           
NAME                                   READY   STATUS    RESTARTS   AGE
argo-ui-596d785685-vzsg5               1/1     Running   8          17d
randomfail-workflow-r8p5w              0/2     Error     0          10s
workflow-controller-689f886b74-qn78p   1/1     Running   5          7d12h
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get wf                                                                                           
NAME                        STATUS      AGE
randomfail-workflow-pfnmf   Succeeded   58s
randomfail-workflow-r8p5w   Failed      13s
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get hc                                                                                           
NAME                     LATEST STATUS   SUCCESS CNT     FAIL CNT   REMEDY SUCCESS CNT     REMEDY FAIL CNT   AGE
fail-healthcheck-xk8d8   Succeeded       3                                                                   2m33s
-----------------------------------------------------------------------------------------------------------------------------------------
Logs:
2020-12-15T08:52:42.382+0530    INFO    controllers.HealthCheck Workflow status {"HealthCheck": "health/fail-healthcheck-xk8d8", "status": "Failed"}
2020-12-15T08:52:42.382+0530    INFO    controllers.HealthCheck Remedy values:  {"HealthCheck": "health/fail-healthcheck-xk8d8", "RemedyTotalRuns:": 0}
2020-12-15T08:52:42.382+0530    INFO    controllers.HealthCheck RemedyWorkflow not empty:       {"HealthCheck": "health/fail-healthcheck-xk8d8"}
2020-12-15T08:52:42.382+0530    INFO    controllers.HealthCheck RemedyRunsLimit and  RemedyResetInterval values are     {"HealthCheck": "health/fail-healthcheck-xk8d8", "RemedyRunsLimit": 2, "RemedyResetInterval": 300}
2020-12-15T08:52:42.382+0530    INFO    controllers.HealthCheck RemedyRunsLimit is greater than  RemedyTotalRuns        {"HealthCheck": "health/fail-healthcheck-xk8d8", "RemedyRunsLimit": 2, "RemedyTotalRuns": 0}
2020-12-15T08:52:42.382+0530    INFO    controllers.HealthCheck Creating Workflow       {"HealthCheck": "health/fail-healthcheck-xk8d8", "namespace": "health", "generateNamePrefix": "remedy-test-"}

-----------------------------------------------------------------------------------------------------------------------------------------

~/(limit-remedy*) » kh get po                                                                                           
NAME                                   READY   STATUS     RESTARTS   AGE
argo-ui-596d785685-vzsg5               1/1     Running    8          17d
randomfail-workflow-r8p5w              0/2     Error      0          22s
remedy-test-mzbgs                      1/2     NotReady   0          7s
workflow-controller-689f886b74-qn78p   1/1     Running    5          7d12h
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get po                                                                                           
NAME                                   READY   STATUS      RESTARTS   AGE
argo-ui-596d785685-vzsg5               1/1     Running     8          17d
randomfail-workflow-r8p5w              0/2     Error       0          25s
remedy-test-mzbgs                      0/2     Completed   0          10s
workflow-controller-689f886b74-qn78p   1/1     Running     5          7d12h
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get wf                                                                                           
NAME                        STATUS      AGE
randomfail-workflow-pfnmf   Succeeded   77s
randomfail-workflow-r8p5w   Failed      32s
remedy-test-mzbgs           Succeeded   17s
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get hc                                                                                           
NAME                     LATEST STATUS   SUCCESS CNT     FAIL CNT   REMEDY SUCCESS CNT     REMEDY FAIL CNT   AGE
fail-healthcheck-xk8d8   Failed          3               1          1                                        2m51s
-----------------------------------------------------------------------------------------------------------------------------------------
Logs:
2020-12-15T08:53:42.587+0530    INFO    controllers.HealthCheck Workflow status {"HealthCheck": "health/fail-healthcheck-xk8d8", "status": "Failed"}
2020-12-15T08:53:42.587+0530    INFO    controllers.HealthCheck Remedy values:  {"HealthCheck": "health/fail-healthcheck-xk8d8", "RemedyTotalRuns:": 1}
2020-12-15T08:53:42.587+0530    INFO    controllers.HealthCheck RemedyWorkflow not empty:       {"HealthCheck": "health/fail-healthcheck-xk8d8"}
2020-12-15T08:53:42.587+0530    INFO    controllers.HealthCheck RemedyRunsLimit and  RemedyResetInterval values are     {"HealthCheck": "health/fail-healthcheck-xk8d8", "RemedyRunsLimit": 2, "RemedyResetInterval": 300}
2020-12-15T08:53:42.587+0530    INFO    controllers.HealthCheck RemedyRunsLimit is greater than  RemedyTotalRuns        {"HealthCheck": "health/fail-healthcheck-xk8d8", "RemedyRunsLimit": 2, "RemedyTotalRuns": 1}
2020-12-15T08:53:42.587+0530    INFO    controllers.HealthCheck Creating Workflow       {"HealthCheck": "health/fail-healthcheck-xk8d8", "namespace": "health", "generateNamePrefix": "remedy-test-"}

-----------------------------------------------------------------------------------------------------------------------------------------
~/(limit-remedy*) » kh get hc                                                                                           
NAME                     LATEST STATUS   SUCCESS CNT     FAIL CNT   REMEDY SUCCESS CNT     REMEDY FAIL CNT   AGE
fail-healthcheck-xk8d8   Failed          3               2          2                                        4m22s
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get hwf                                                                                          
error: the server doesn't have a resource type "hwf"
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get wf                                                                                       1 ↵ 
NAME                        STATUS      AGE
randomfail-workflow-f7k79   Failed      72s
randomfail-workflow-fjph7   Succeeded   12s
randomfail-workflow-pfnmf   Succeeded   2m57s
randomfail-workflow-r8p5w   Failed      2m12s
remedy-test-jj9dk           Succeeded   57s
remedy-test-mzbgs           Succeeded   117s
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get po                                                                                           
NAME                                   READY   STATUS    RESTARTS   AGE
argo-ui-596d785685-vzsg5               1/1     Running   8          17d
randomfail-workflow-f7k79              0/2     Error     0          81s
randomfail-workflow-r8p5w              0/2     Error     0          2m21s
workflow-controller-689f886b74-qn78p   1/1     Running   5          7d12h
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get po                                                                                           
NAME                                   READY   STATUS              RESTARTS   AGE
argo-ui-596d785685-vzsg5               1/1     Running             8          17d
randomfail-workflow-f7k79              0/2     Error               0          107s
randomfail-workflow-jfq7r              0/2     ContainerCreating   0          2s
randomfail-workflow-r8p5w              0/2     Error               0          2m47s
workflow-controller-689f886b74-qn78p   1/1     Running             5          7d12h
----------------------------------------------------------------------------~/(limit-remedy*) » kh get po                                                                                           
NAME                                   READY   STATUS     RESTARTS   AGE
argo-ui-596d785685-vzsg5               1/1     Running    8          17d
randomfail-workflow-f7k79              0/2     Error      0          113s
randomfail-workflow-jfq7r              1/2     NotReady   0          8s
randomfail-workflow-r8p5w              0/2     Error      0          2m53s
workflow-controller-689f886b74-qn78p   1/1     Running    5          7d12h
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get po                                                                                           
NAME                                   READY   STATUS    RESTARTS   AGE
argo-ui-596d785685-vzsg5               1/1     Running   8          17d
randomfail-workflow-f7k79              0/2     Error     0          117s
randomfail-workflow-r8p5w              0/2     Error     0          2m57s
workflow-controller-689f886b74-qn78p   1/1     Running   5          7d12h
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get wf                                                                                           
NAME                        STATUS      AGE
randomfail-workflow-f7k79   Failed      2m2s
randomfail-workflow-fjph7   Succeeded   62s
randomfail-workflow-jfq7r   Succeeded   17s
randomfail-workflow-pfnmf   Succeeded   3m47s
randomfail-workflow-r8p5w   Failed      3m2s
remedy-test-jj9dk           Succeeded   107s
remedy-test-mzbgs           Succeeded   2m47s
-----------------------------------------------------------------------------------------------------------------------------------------~/(limit-remedy*) » kh get hc                                                                                           
NAME                     LATEST STATUS   SUCCESS CNT     FAIL CNT   REMEDY SUCCESS CNT     REMEDY FAIL CNT   AGE
fail-healthcheck-xk8d8   Succeeded       5               2                                                   5m25s

Logs:
----------------------------------------------------------------------------------------------------------------------------------------
2020-12-15T08:54:42.780+0530    INFO    controllers.HealthCheck Workflow status {"HealthCheck": "health/fail-healthcheck-xk8d8", "status": "Succeeded"}
2020-12-15T08:54:42.780+0530    INFO    controllers.HealthCheck Time:   {"HealthCheck": "health/fail-healthcheck-xk8d8", "hc.Status.StartedAt:": "2020-12-15 08:54:27.760945 +0530 IST m=+1136.127591869"}
2020-12-15T08:54:42.780+0530    INFO    controllers.HealthCheck Time:   {"HealthCheck": "health/fail-healthcheck-xk8d8", "hc.Status.FinishedAt:": "2020-12-15 08:54:42.773379 +0530 IST m=+1151.139842747"}
2020-12-15T08:54:42.780+0530    INFO    controllers.HealthCheck HealthCheck passed so Remedy is reset   {"HealthCheck": "health/fail-healthcheck-xk8d8", "RemedyTotalRuns:": 0, "RemedySuccessCount": 0, "RemedyFailedCount": 0}
```