### PR TITLE
fix for issue-82 leaking timers and add update to status suresource

### DIFF
--- a/api/v1alpha1/healthcheck_types.go
+++ b/api/v1alpha1/healthcheck_types.go
@@ -61,6 +61,7 @@ type HealthCheckStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:path=healthchecks,scope=Namespaced,shortName=hc;hcs
 // +kubebuilder:printcolumn:name="LATEST STATUS",type=string,JSONPath=`.status.status`
 // +kubebuilder:printcolumn:name="SUCCESS CNT  ",type=string,JSONPath=`.status.successCount`

--- a/config/crd/bases/activemonitor.keikoproj.io_healthchecks.yaml
+++ b/config/crd/bases/activemonitor.keikoproj.io_healthchecks.yaml
@@ -37,7 +37,8 @@ spec:
     - hcs
     singular: healthcheck
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: HealthCheck is the Schema for the healthchecks API


### PR DESCRIPTION
Fixes issue #82 

## Proposed Changes
  - stop timers when there is a failure in updating the custom resource
  - Update status subresource instead of full object.
  
## Testing Done
  - All the functional tests are run.
  ```
apiVersion: v1
items:
- apiVersion: activemonitor.keikoproj.io/v1alpha1
  kind: HealthCheck
  metadata:
    creationTimestamp: "2021-03-03T10:25:05Z"
    generation: 2
    managedFields:
    - apiVersion: activemonitor.keikoproj.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        f:spec:
          .: {}
          f:level: {}
          f:schedule:
            .: {}
            f:cron: {}
          f:workflow:
            .: {}
            f:generateName: {}
            f:resource:
              .: {}
              f:namespace: {}
              f:serviceAccount: {}
              f:source:
                .: {}
                f:inline: {}
      manager: kubectl-create
      operation: Update
      time: "2021-03-03T10:25:05Z"
    - apiVersion: activemonitor.keikoproj.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        f:spec:
          f:remedyworkflow: {}
          f:repeatAfterSec: {}
          f:workflow:
            f:workflowtimeout: {}
        f:status:
          .: {}
          f:finishedAt: {}
          f:lastSuccessfulWorkflow: {}
          f:startedAt: {}
          f:status: {}
          f:successCount: {}
          f:totalHealthCheckRuns: {}
      manager: main
      operation: Update
      time: "2021-03-03T10:25:35Z"
    name: inline-hello
    namespace: health
    resourceVersion: "116681"
    uid: e75ab6d8-3fac-4840-9c8b-5c11b062f01e
  spec:
    level: cluster
    remedyworkflow: {}
    repeatAfterSec: 60
    schedule:
      cron: '@every 1m'
    workflow:
      generateName: inline-hello-
      resource:
        namespace: health
        serviceAccount: activemonitor-controller-sa
        source:
          inline: |
            apiVersion: argoproj.io/v1alpha1
            kind: Workflow
            metadata:
              labels:
                workflows.argoproj.io/controller-instanceid: activemonitor-workflows
              generateName: hello-world-
            spec:
              entrypoint: whalesay
              templates:
                -
                  container:
                    args:
                      - "hello world"
                    command:
                      - cowsay
                    image: "docker/whalesay:latest"
                  name: whalesay
      workflowtimeout: 60
  status:
    finishedAt: "2021-03-03T10:34:28Z"
    lastSuccessfulWorkflow: inline-hello-6c8ht
    startedAt: "2021-03-03T10:33:58Z"
    status: Succeeded
    successCount: 5
    totalHealthCheckRuns: 5
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```