### PR TITLE
fix for issue-82 leaking timers and add update to status suresource

### DIFF
--- a/api/v1alpha1/healthcheck_types.go
+++ b/api/v1alpha1/healthcheck_types.go
@@ -61,6 +61,7 @@ type HealthCheckStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:path=healthchecks,scope=Namespaced,shortName=hc;hcs
 // +kubebuilder:printcolumn:name="LATEST STATUS",type=string,JSONPath=`.status.status`
 // +kubebuilder:printcolumn:name="SUCCESS CNT  ",type=string,JSONPath=`.status.successCount`

--- a/config/crd/bases/activemonitor.keikoproj.io_healthchecks.yaml
+++ b/config/crd/bases/activemonitor.keikoproj.io_healthchecks.yaml
@@ -37,7 +37,8 @@ spec:
     - hcs
     singular: healthcheck
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: HealthCheck is the Schema for the healthchecks API

--- a/controllers/healthcheck_controller.go
+++ b/controllers/healthcheck_controller.go
@@ -19,6 +19,8 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"strings"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -145,7 +147,14 @@ func (r *HealthCheckReconciler) processOrRecoverHealthCheck(ctx context.Context,
 	}()
 	// Process HealthCheck
 	ret, procErr := r.processHealthCheck(ctx, log, healthCheck)
-
+	if procErr != nil {
+		log.Error(procErr, "Workflow for this healthcheck has an error")
+		if r.IsStorageError(procErr) {
+			// avoid update errors for resources already deleted
+			return ctrl.Result{}, nil
+		}
+		return reconcile.Result{RequeueAfter: 1 * time.Second}, procErr
+	}
 	err := r.Update(ctx, healthCheck)
 	if err != nil {
 		log.Error(err, "Error updating healthcheck resource")
@@ -174,6 +183,12 @@ func (r *HealthCheckReconciler) processHealthCheck(ctx context.Context, log logr
 			healthCheck.Status.ErrorMessage = fmt.Sprintf("workflow execution is stopped; either spec.RepeatAfterSec or spec.Schedule must be provided. spec.RepeatAfterSec set to %d. spec.Schedule set to %+v", hcSpec.RepeatAfterSec, hcSpec.Schedule)
 			healthCheck.Status.FinishedAt = &now
 			r.Recorder.Event(healthCheck, v1.EventTypeWarning, "Warning", "Workflow execution is stopped; either spec.RepeatAfterSec or spec.Schedule must be provided")
+			err := r.updateHealthCheckStatus(ctx, log, healthCheck)
+			if err != nil {
+				log.Error(err, "Error updating healthcheck resource")
+				r.Recorder.Event(healthCheck, v1.EventTypeWarning, "Warning", "Error updating healthcheck resource")
+				return ctrl.Result{}, err
+			}
 			return ctrl.Result{}, nil
 		} else if hcSpec.RepeatAfterSec <= 0 && hcSpec.Schedule.Cron != "" {
 			log.Info("Workflow to be set with Schedule", "Cron", hcSpec.Schedule.Cron)
@@ -645,10 +660,16 @@ func (r *HealthCheckReconciler) watchWorkflowReschedule(ctx context.Context, req
 	// see: https://book.kubebuilder.io/reference/using-finalizers.html
 	if hc.ObjectMeta.DeletionTimestamp.IsZero() {
 		// since the underlying workflow has completed, we update the healthcheck accordingly
-		err := r.Update(ctx, hc)
+		err := r.updateHealthCheckStatus(ctx, log, hc)
 		if err != nil {
 			log.Error(err, "Error updating healthcheck resource")
 			r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Error updating healthcheck resource")
+			if r.RepeatTimersByName[req.NamespacedName.Name] != nil {
+				log.Info("Cancelling rescheduled workflow for this healthcheck due to deletion")
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Cancelling workflow for this healthcheck due to deletion")
+				r.RepeatTimersByName[hc.GetName()].Stop()
+			}
+			return err
 		}
 		// reschedule next run of workflow
 		helper := r.createSubmitWorkflowHelper(ctx, log, wfNamespace, hc)
@@ -760,10 +781,16 @@ func (r *HealthCheckReconciler) watchRemedyWorkflow(ctx context.Context, req ctr
 	// see: https://book.kubebuilder.io/reference/using-finalizers.html
 	if hc.ObjectMeta.DeletionTimestamp.IsZero() {
 		// since the underlying workflow has completed, we update the healthcheck accordingly
-		err := r.Update(ctx, hc)
+		err := r.updateHealthCheckStatus(ctx, log, hc)
 		if err != nil {
 			log.Error(err, "Error updating healthcheck resource")
 			r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Error updating healthcheck resource")
+			if r.RepeatTimersByName[req.NamespacedName.Name] != nil {
+				log.Info("Cancelling rescheduled workflow for this healthcheck due to deletion")
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Cancelling workflow for this healthcheck due to deletion")
+				r.RepeatTimersByName[hc.GetName()].Stop()
+			}
+			return err
 		}
 	}
 
@@ -869,7 +896,7 @@ func (r *HealthCheckReconciler) parseWorkflowFromHealthcheck(log logr.Logger, hc
 	if activeDeadlineSeconds := data["spec"].(map[string]interface{})["activeDeadlineSeconds"]; activeDeadlineSeconds == nil {
 		data["spec"].(map[string]interface{})["activeDeadlineSeconds"] = &timeout
 	}
-	log.Info("HealthCheck with Workflow", "Spec:", data)
+	//log.Info("HealthCheck with Workflow", "Spec:", data)
 	spec, ok := data["spec"]
 	if !ok {
 		err := errors.New("invalid workflow, missing spec")
@@ -1268,4 +1295,30 @@ func (r *HealthCheckReconciler) DeleteClusterRoleBinding(clientset kubernetes.In
 
 	return nil
 
+}
+
+func (r *HealthCheckReconciler) updateHealthCheckStatus(ctx context.Context, log logr.Logger, hc *activemonitorv1alpha1.HealthCheck) error {
+	if err := r.Status().Update(ctx, hc); err != nil {
+		log.Error(err, "HealthCheck status could not be updated.")
+		r.Recorder.Event(hc, "Warning", "Failed", fmt.Sprintf("HealthCheck %s/%s status could not be updated. %v", hc.Namespace, hc.Name, err))
+		return err
+	}
+
+	return nil
+}
+
+func (r *HealthCheckReconciler) ContainsEqualFoldSubstring(str, substr string) bool {
+	x := strings.ToLower(str)
+	y := strings.ToLower(substr)
+	if strings.Contains(x, y) {
+		return true
+	}
+	return false
+}
+
+func (r *HealthCheckReconciler) IsStorageError(err error) bool {
+	if r.ContainsEqualFoldSubstring(err.Error(), "StorageError: invalid object") {
+		return true
+	}
+	return false
 }

--- a/controllers/healthcheck_controller.go
+++ b/controllers/healthcheck_controller.go
@@ -896,7 +896,7 @@ func (r *HealthCheckReconciler) parseWorkflowFromHealthcheck(log logr.Logger, hc
 	if activeDeadlineSeconds := data["spec"].(map[string]interface{})["activeDeadlineSeconds"]; activeDeadlineSeconds == nil {
 		data["spec"].(map[string]interface{})["activeDeadlineSeconds"] = &timeout
 	}
-	//log.Info("HealthCheck with Workflow", "Spec:", data)
+	log.Info("HealthCheck with Workflow", "Spec:", data)
 	spec, ok := data["spec"]
 	if !ok {
 		err := errors.New("invalid workflow, missing spec")


### PR DESCRIPTION
Signed-off-by: Ravi Hari <ravireliable@gmail.com>

Fixes issue #82 

## Proposed Changes
  - stop timers when there is a failure in updating the custom resource
  - Update status subresource instead of full object.
  
## Testing Done
  - Unit Tests
```
go test ./api/... ./controllers/... ./metrics/... ./store/... -coverprofile coverage.txt
ok      github.com/keikoproj/active-monitor/api/v1alpha1        4.825s  coverage: 0.8% of statements
ok      github.com/keikoproj/active-monitor/controllers 30.752s coverage: 68.0% of statements
ok      github.com/keikoproj/active-monitor/metrics     0.892s  coverage: 81.8% of statements
?       github.com/keikoproj/active-monitor/store       [no test files]

```
  - All the functional tests are run.
  ```
apiVersion: v1
items:
- apiVersion: activemonitor.keikoproj.io/v1alpha1
  kind: HealthCheck
  metadata:
    creationTimestamp: "2021-03-03T10:25:05Z"
    generation: 2
    managedFields:
    - apiVersion: activemonitor.keikoproj.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        f:spec:
          .: {}
          f:level: {}
          f:schedule:
            .: {}
            f:cron: {}
          f:workflow:
            .: {}
            f:generateName: {}
            f:resource:
              .: {}
              f:namespace: {}
              f:serviceAccount: {}
              f:source:
                .: {}
                f:inline: {}
      manager: kubectl-create
      operation: Update
      time: "2021-03-03T10:25:05Z"
    - apiVersion: activemonitor.keikoproj.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        f:spec:
          f:remedyworkflow: {}
          f:repeatAfterSec: {}
          f:workflow:
            f:workflowtimeout: {}
        f:status:
          .: {}
          f:finishedAt: {}
          f:lastSuccessfulWorkflow: {}
          f:startedAt: {}
          f:status: {}
          f:successCount: {}
          f:totalHealthCheckRuns: {}
      manager: main
      operation: Update
      time: "2021-03-03T10:25:35Z"
    name: inline-hello
    namespace: health
    resourceVersion: "116681"
    uid: e75ab6d8-3fac-4840-9c8b-5c11b062f01e
  spec:
    level: cluster
    remedyworkflow: {}
    repeatAfterSec: 60
    schedule:
      cron: '@every 1m'
    workflow:
      generateName: inline-hello-
      resource:
        namespace: health
        serviceAccount: activemonitor-controller-sa
        source:
          inline: |
            apiVersion: argoproj.io/v1alpha1
            kind: Workflow
            metadata:
              labels:
                workflows.argoproj.io/controller-instanceid: activemonitor-workflows
              generateName: hello-world-
            spec:
              entrypoint: whalesay
              templates:
                -
                  container:
                    args:
                      - "hello world"
                    command:
                      - cowsay
                    image: "docker/whalesay:latest"
                  name: whalesay
      workflowtimeout: 60
  status:
    finishedAt: "2021-03-03T10:34:28Z"
    lastSuccessfulWorkflow: inline-hello-6c8ht
    startedAt: "2021-03-03T10:33:58Z"
    status: Succeeded
    successCount: 5
    totalHealthCheckRuns: 5
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```