### PR TITLE
Update CHANGELOG and README to begin 0.5.2 release process

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 Bleeding-edge development, not yet released
 
+## [0.5.2] - 2021-05-18
+### Fixed
+- Active Monitor crashing with concurrent map updates - #88
+
 ## [0.5.1] - 2021-03-05
 ### Fixed
 - active-monitor running workflows more frequently than the configuration - #82
@@ -47,7 +51,8 @@ Bleeding-edge development, not yet released
 ### Added
 - Initial commit of project
 
-[Unreleased]: https://github.com/keikoproj/active-monitor/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/keikoproj/active-monitor/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/keikoproj/active-monitor/releases/tag/v0.5.1
 [0.5.1]: https://github.com/keikoproj/active-monitor/releases/tag/v0.5.1
 [0.5.0]: https://github.com/keikoproj/active-monitor/releases/tag/v0.5.0
 [0.4.0]: https://github.com/keikoproj/active-monitor/releases/tag/v0.4.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PR](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)][GithubPrsUrl]
 [![slack](https://img.shields.io/badge/slack-join%20the%20conversation-ff69b4.svg)][SlackUrl]
 
-![version](https://img.shields.io/badge/version-0.5.1-blue.svg?cacheSeconds=2592000)
+![version](https://img.shields.io/badge/version-0.5.2-blue.svg?cacheSeconds=2592000)
 [![Build Status][BuildStatusImg]][BuildMasterUrl]
 [![codecov][CodecovImg]][CodecovUrl]
 [![Go Report Card][GoReportImg]][GoReportUrl]


### PR DESCRIPTION
#92 
[0.5.2] - 2021-05-18
Fixed
- Active Monitor crashing with concurrent map updates - #88
