### PR TITLE
Update Default TTL Strategy to secondsAfterCompletion

### DIFF
--- a/controllers/healthcheck_controller.go
+++ b/controllers/healthcheck_controller.go
@@ -54,7 +54,6 @@ const (
 	wfResource                = "workflows"
 	succStr                   = "Succeeded"
 	failStr                   = "Failed"
-	defaultWorkflowTTLSec     = 1800
 	remedy                    = "remedy"
 	healthcheck               = "healthCheck"
 	healthCheckClusterLevel   = "cluster"

--- a/controllers/healthcheck_controller.go
+++ b/controllers/healthcheck_controller.go
@@ -888,9 +888,6 @@ func (r *HealthCheckReconciler) parseWorkflowFromHealthcheck(log logr.Logger, hc
 		hc.Spec.Workflow.Timeout = hc.Spec.RepeatAfterSec
 		timeout = int64(hc.Spec.Workflow.Timeout)
 	}
-	if ttlSecondAfterFinished := data["spec"].(map[string]interface{})["ttlSecondsAfterFinished"]; ttlSecondAfterFinished == nil {
-		data["spec"].(map[string]interface{})["ttlSecondsAfterFinished"] = defaultWorkflowTTLSec
-	}
 	// set service account, if specified
 	if hc.Spec.Workflow.Resource.ServiceAccount != "" {
 		data["spec"].(map[string]interface{})["serviceAccountName"] = hc.Spec.Workflow.Resource.ServiceAccount
@@ -990,10 +987,6 @@ func (r *HealthCheckReconciler) parseRemedyWorkflowFromHealthcheck(log logr.Logg
 	if podGC := data["spec"].(map[string]interface{})["podGC"]; podGC == nil {
 		data["spec"].(map[string]interface{})["podGC"] = &pgc
 	}
-	// make sure workflows by default get cleaned up
-	if ttlSecondAfterFinished := data["spec"].(map[string]interface{})["ttlSecondsAfterFinished"]; ttlSecondAfterFinished == nil {
-		data["spec"].(map[string]interface{})["ttlSecondsAfterFinished"] = defaultWorkflowTTLSec
-	}
 	// set service account, if specified
 	if hc.Spec.RemedyWorkflow.Resource.ServiceAccount != "" {
 		data["spec"].(map[string]interface{})["serviceAccountName"] = hc.Spec.RemedyWorkflow.Resource.ServiceAccount
@@ -1016,6 +1009,7 @@ func (r *HealthCheckReconciler) parseRemedyWorkflowFromHealthcheck(log logr.Logg
 		r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Invalid remedy workflow template spec")
 		return err
 	}
+	log.Info("spec after updating:", spec)
 	content["spec"] = spec
 	uwf.SetUnstructuredContent(content)
 	r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Remedy workflow is parsed from healthcheck")

--- a/controllers/healthcheck_controller.go
+++ b/controllers/healthcheck_controller.go
@@ -897,7 +897,6 @@ func (r *HealthCheckReconciler) parseWorkflowFromHealthcheck(log logr.Logger, hc
 	if activeDeadlineSeconds := data["spec"].(map[string]interface{})["activeDeadlineSeconds"]; activeDeadlineSeconds == nil {
 		data["spec"].(map[string]interface{})["activeDeadlineSeconds"] = &timeout
 	}
-	log.Info("HealthCheck with Workflow", "Spec:", data)
 	spec, ok := data["spec"]
 	if !ok {
 		err := errors.New("invalid workflow, missing spec")
@@ -1009,7 +1008,6 @@ func (r *HealthCheckReconciler) parseRemedyWorkflowFromHealthcheck(log logr.Logg
 		r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Invalid remedy workflow template spec")
 		return err
 	}
-	log.Info("spec after updating:", spec)
 	content["spec"] = spec
 	uwf.SetUnstructuredContent(content)
 	r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Remedy workflow is parsed from healthcheck")

--- a/deploy/deploy-argo.yaml
+++ b/deploy/deploy-argo.yaml
@@ -438,15 +438,9 @@ data:
   instanceID: activemonitor-workflows
   namespace: health
   workflowDefaults: |
-    metadata:
-      annotations:
-        argo: workflows
-      labels:
-        app: workflow-controller
     spec:
       ttlStrategy:
         SecondsAfterCompletion: 1800
-
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/deploy-argo.yaml
+++ b/deploy/deploy-argo.yaml
@@ -435,9 +435,18 @@ metadata:
   name: workflow-controller-configmap
   namespace: health
 data:
-  config: |
-    instanceID: activemonitor-workflows
-    namespace: health
+  instanceID: activemonitor-workflows
+  namespace: health
+  workflowDefaults: |
+    metadata:
+      annotations:
+        argo: workflows
+      labels:
+        app: workflow-controller
+    spec:
+      ttlStrategy:
+        SecondsAfterCompletion: 1800
+
 ---
 apiVersion: v1
 kind: Service

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,6 @@ require (
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v0.17.2
-	k8s.io/utils v0.0.0-20191218082557-f07c713de883
+	k8s.io/utils v0.0.0-20191218082557-f07c713de883 // indirect
 	sigs.k8s.io/controller-runtime v0.5.0
 )

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,6 @@ require (
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v0.17.2
-	k8s.io/utils v0.0.0-20191218082557-f07c713de883 // indirect
+	k8s.io/utils v0.0.0-20191218082557-f07c713de883
 	sigs.k8s.io/controller-runtime v0.5.0
 )


### PR DESCRIPTION
Fixes issue #99

## Proposed Changes
  - remove ttlSecondAfterFinished which is deprecated in workflows 3.x
  - use ttlstrategy from configmap instead of setting it from code.
  
## Testing Done
  - All regular cases are tested.
  ```
Name:         inline-hello
Namespace:    health
Labels:       <none>
Annotations:  <none>
API Version:  activemonitor.keikoproj.io/v1alpha1
Kind:         HealthCheck
Metadata:
  Creation Timestamp:  2021-06-15T15:49:30Z
  Generation:          2
  Managed Fields:
    API Version:  activemonitor.keikoproj.io/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:level:
        f:schedule:
          .:
          f:cron:
        f:workflow:
          .:
          f:generateName:
          f:resource:
            .:
            f:namespace:
            f:serviceAccount:
            f:source:
              .:
              f:inline:
    Manager:      kubectl-create
    Operation:    Update
    Time:         2021-06-15T15:49:30Z
    API Version:  activemonitor.keikoproj.io/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        f:remedyworkflow:
        f:repeatAfterSec:
        f:workflow:
          f:workflowtimeout:
      f:status:
        .:
        f:finishedAt:
        f:lastSuccessfulWorkflow:
        f:startedAt:
        f:status:
        f:successCount:
        f:totalHealthCheckRuns:
    Manager:         main
    Operation:       Update
    Time:            2021-06-15T15:50:00Z
  Resource Version:  682098
  UID:               0a2576f0-23cc-45b6-b986-99846ce8b9ee
Spec:
  Level:  cluster
  Remedyworkflow:
  Repeat After Sec:  60
  Schedule:
    Cron:  @every 1m
  Workflow:
    Generate Name:  inline-hello-
    Resource:
      Namespace:        health
      Service Account:  activemonitor-controller-sa
      Source:
        Inline:  apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  labels:
    workflows.argoproj.io/controller-instanceid: activemonitor-workflows
  generateName: hello-world-
spec:
  entrypoint: whalesay
  templates:
    -
      container:
        args:
          - "hello world"
        command:
          - cowsay
        image: "docker/whalesay:latest"
      name: whalesay

    Workflowtimeout:  60
Status:
  Finished At:               2021-06-15T15:50:00Z
  Last Successful Workflow:  inline-hello-4w2w8
  Started At:                2021-06-15T15:49:30Z
  Status:                    Succeeded
  Success Count:             1
  Total Health Check Runs:   1
Events:
  Type    Reason  Age    From         Message
  ----    ------  ----   ----         -------
  Normal  Normal  5m47s  HealthCheck  Successfully Created ServiceAccount
  Normal  Normal  5m47s  HealthCheck  Successfully Created clusterrole
  Normal  Normal  5m47s  HealthCheck  Successfully Created ClusterRoleBinding
  Normal  Normal  5m47s  HealthCheck  workflow is parsed from healthcheck
  Normal  Normal  5m47s  HealthCheck  Successfully created workflow
  Normal  Normal  5m17s  HealthCheck  Workflow status is Succeeded
  Normal  Normal  5m17s  HealthCheck  Rescheduled workflow for next run
```

Workflow

```
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  creationTimestamp: "2021-06-15T15:49:30Z"
  generateName: inline-hello-
  generation: 3
  labels:
    workflows.argoproj.io/completed: "true"
    workflows.argoproj.io/controller-instanceid: activemonitor-workflows
    workflows.argoproj.io/phase: Succeeded
  managedFields:
  - apiVersion: argoproj.io/v1alpha1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:generateName: {}
        f:labels:
          .: {}
          f:workflows.argoproj.io/controller-instanceid: {}
        f:ownerReferences:
          .: {}
          k:{"uid":"0a2576f0-23cc-45b6-b986-99846ce8b9ee"}:
            .: {}
            f:apiVersion: {}
            f:controller: {}
            f:kind: {}
            f:name: {}
            f:uid: {}
      f:spec:
        .: {}
        f:activeDeadlineSeconds: {}
        f:entrypoint: {}
        f:podGC:
          .: {}
          f:strategy: {}
        f:serviceAccountName: {}
    manager: main
    operation: Update
    time: "2021-06-15T15:49:30Z"
  - apiVersion: argoproj.io/v1alpha1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:labels:
          f:workflows.argoproj.io/completed: {}
          f:workflows.argoproj.io/phase: {}
      f:spec:
        f:arguments: {}
        f:templates: {}
        f:ttlStrategy:
          .: {}
          f:secondsAfterCompletion: {}
      f:status:
        .: {}
        f:artifactRepositoryRef:
          .: {}
          f:default: {}
        f:conditions: {}
        f:finishedAt: {}
        f:nodes:
          .: {}
          f:inline-hello-4w2w8:
            .: {}
            f:displayName: {}
            f:finishedAt: {}
            f:id: {}
            f:name: {}
            f:outputs:
              .: {}
              f:exitCode: {}
            f:phase: {}
            f:progress: {}
            f:resourcesDuration:
              .: {}
              f:cpu: {}
              f:memory: {}
            f:startedAt: {}
            f:templateName: {}
            f:templateScope: {}
            f:type: {}
        f:phase: {}
        f:progress: {}
        f:resourcesDuration:
          .: {}
          f:cpu: {}
          f:memory: {}
        f:startedAt: {}
    manager: workflow-controller
    operation: Update
    time: "2021-06-15T15:49:40Z"
  name: inline-hello-4w2w8
  namespace: health
  ownerReferences:
  - apiVersion: v1alpha1
    controller: true
    kind: HealthCheck
    name: inline-hello
    uid: 0a2576f0-23cc-45b6-b986-99846ce8b9ee
  resourceVersion: "682073"
  uid: 5f40bf29-bd3a-473b-89d6-c747edfa30f7
spec:
  activeDeadlineSeconds: 60
  arguments: {}
  entrypoint: whalesay
  podGC:
    strategy: OnPodCompletion
  serviceAccountName: activemonitor-controller-sa
  templates:
  - container:
      args:
      - hello world
      command:
      - cowsay
      image: docker/whalesay:latest
      name: ""
      resources: {}
    inputs: {}
    metadata: {}
    name: whalesay
    outputs: {}
  ttlStrategy:
    secondsAfterCompletion: 1800
status:
  artifactRepositoryRef:
    default: true
  conditions:
  - status: "False"
    type: PodRunning
  - status: "True"
    type: Completed
  finishedAt: "2021-06-15T15:49:40Z"
  nodes:
    inline-hello-4w2w8:
      displayName: inline-hello-4w2w8
      finishedAt: "2021-06-15T15:49:38Z"
      id: inline-hello-4w2w8
      name: inline-hello-4w2w8
      outputs:
        exitCode: "0"
      phase: Succeeded
      progress: 1/1
      resourcesDuration:
        cpu: 7
        memory: 7
      startedAt: "2021-06-15T15:49:30Z"
      templateName: whalesay
      templateScope: local/inline-hello-4w2w8
      type: Pod
  phase: Succeeded
  progress: 1/1
  resourcesDuration:
    cpu: 7
    memory: 7
  startedAt: "2021-06-15T15:49:30Z"
```
  - Unit Tests
 ```
go test ./api/... ./controllers/... ./metrics/... ./store/... -coverprofile coverage.txt
ok      github.com/keikoproj/active-monitor/api/v1alpha1        5.164s  coverage: 0.8% of statements
ok      github.com/keikoproj/active-monitor/controllers 30.596s coverage: 66.9% of statements
ok      github.com/keikoproj/active-monitor/metrics     0.837s  coverage: 81.8% of statements
```