### PR TITLE
add lock for workflowlables read and writes.

### DIFF
--- a/controllers/healthcheck_controller.go
+++ b/controllers/healthcheck_controller.go
@@ -851,12 +851,14 @@ func (r *HealthCheckReconciler) parseWorkflowFromHealthcheck(log logr.Logger, hc
 			}
 		}
 		log.Info("Workflow Labels set are:", "wflabel:", r.workflowLabels)
+		r.TimerLock.Unlock()
 	} else {
 		log.Info("metadata for workflow is not set")
 		type metadata struct {
 			generateName string
 			labels       map[string]string
 		}
+		r.TimerLock.Lock()
 		if r.workflowLabels == nil {
 			r.workflowLabels = make(map[string]string)
 		}
@@ -865,10 +867,10 @@ func (r *HealthCheckReconciler) parseWorkflowFromHealthcheck(log logr.Logger, hc
 		r.workflowLabels[WfInstanceIdLabelKey] = WfInstanceId
 		m1 := metadata{generateName: hc.Spec.Workflow.GenerateName, labels: r.workflowLabels}
 		data["metadata"] = m1
-		log.Info("Workflow Labels are set:", "wflabel:", r.workflowLabels)
 		log.Info("metadata for Workflow is updated", "metadata generateName:", m1.generateName, "metadata label:", m1.labels)
+		log.Info("Workflow Labels are set:", "wflabel:", r.workflowLabels)
+		r.TimerLock.Unlock()
 	}
-	r.TimerLock.Unlock()
 
 	content := uwf.UnstructuredContent()
 	type PodGCStrategy string
@@ -947,6 +949,7 @@ func (r *HealthCheckReconciler) parseRemedyWorkflowFromHealthcheck(log logr.Logg
 		if r.workflowLabels == nil {
 			r.workflowLabels = make(map[string]string)
 		}
+
 		//assign instanceId labels to workflows
 		if wflabels == nil {
 			r.workflowLabels[WfInstanceIdLabelKey] = WfInstanceId
@@ -957,12 +960,14 @@ func (r *HealthCheckReconciler) parseRemedyWorkflowFromHealthcheck(log logr.Logg
 			}
 		}
 		log.Info("Workflow Labels set are:", "wflabel:", r.workflowLabels)
+		r.TimerLock.Unlock()
 	} else {
 		log.Info("metadata for workflow is not set")
 		type metadata struct {
 			generateName string
 			labels       map[string]string
 		}
+		r.TimerLock.Lock()
 		if r.workflowLabels == nil {
 			r.workflowLabels = make(map[string]string)
 		}
@@ -971,9 +976,9 @@ func (r *HealthCheckReconciler) parseRemedyWorkflowFromHealthcheck(log logr.Logg
 		r.workflowLabels[WfInstanceIdLabelKey] = WfInstanceId
 		m1 := metadata{generateName: hc.Spec.Workflow.GenerateName, labels: r.workflowLabels}
 		data["metadata"] = m1
+		log.Info("metadata for Workflow is updated", "metadata generateName:", m1.generateName, "metadata label:", m1.labels)
 		log.Info("Workflow Labels are set:", "wflabel:", r.workflowLabels)
 		r.TimerLock.Unlock()
-		log.Info("metadata for Workflow is updated", "metadata generateName:", m1.generateName, "metadata label:", m1.labels)
 	}
 
 	content := uwf.UnstructuredContent()


### PR DESCRIPTION
Signed-off-by: Ravi Hari <ravireliable@gmail.com>

Fixes issue #98 

## Proposed Changes
  - Add lock for workflowlables read and writes.
  
## Testing Done
  - all use cases and unit Tests:
```
go test ./api/... ./controllers/... ./metrics/... ./store/... -coverprofile coverage.txt
ok      github.com/keikoproj/active-monitor/api/v1alpha1        5.900s  coverage: 0.8% of statements
ok      github.com/keikoproj/active-monitor/controllers 35.577s coverage: 68.4% of statements
ok      github.com/keikoproj/active-monitor/metrics     0.678s  coverage: 81.8% of statements
?       github.com/keikoproj/active-monitor/store       [no test files]
```