### PR TITLE
fixed rbac and sa deletion issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 Bleeding-edge development, not yet released
 
+## [0.8.0] - 2022-08-18
+## Updated
+- Update active-monitor CRD from v1beta1 to v1 - #105
+- Update go version to 1.18 - #111
+### Fixed
+- Fix CHANGELOG file - #110
+- Fix after upgrade argo BDD fails with errors - #109
+
+## [0.7.0] - 2022-03-11
+## Updated
+- Update Argo workflow controller version to v3.2.6 - #107
+
 ## [0.6.0] - 2021-06-17
 ### Added
 - Move to Github Actions for CI enhancement - #81
@@ -60,7 +72,9 @@ Bleeding-edge development, not yet released
 ### Added
 - Initial commit of project
 
-[Unreleased]: https://github.com/keikoproj/active-monitor/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/keikoproj/active-monitor/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/keikoproj/active-monitor/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/keikoproj/active-monitor/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/keikoproj/active-monitor/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/keikoproj/active-monitor/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/keikoproj/active-monitor/compare/v0.5.0...v0.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 Bleeding-edge development, not yet released
 
+## [0.9.0] - 2022-09-01
+## Updated
+- Update workflow-controller and argo-exec version to v3.3.9 - #117
+
 ## [0.8.0] - 2022-08-18
 ## Updated
 - Update active-monitor CRD from v1beta1 to v1 - #105
@@ -72,7 +76,8 @@ Bleeding-edge development, not yet released
 ### Added
 - Initial commit of project
 
-[Unreleased]: https://github.com/keikoproj/active-monitor/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/keikoproj/active-monitor/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/keikoproj/active-monitor/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/keikoproj/active-monitor/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/keikoproj/active-monitor/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/keikoproj/active-monitor/compare/v0.5.2...v0.6.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PR](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)][GithubPrsUrl]
 [![slack](https://img.shields.io/badge/slack-join%20the%20conversation-ff69b4.svg)][SlackUrl]
 
-![version](https://img.shields.io/badge/version-0.6.0-blue.svg?cacheSeconds=2592000)
+![version](https://img.shields.io/badge/version-0.9.0-blue.svg?cacheSeconds=2592000)
 [![Build Status][BuildStatusImg]][BuildMasterUrl]
 [![codecov][CodecovImg]][CodecovUrl]
 [![Go Report Card][GoReportImg]][GoReportUrl]

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -31,6 +31,7 @@ rules:
   resources:
   - workflow
   - workflows
+  - workflowtaskresults
   - workflowtasksets
   verbs:
   - create

--- a/controllers/healthcheck_controller.go
+++ b/controllers/healthcheck_controller.go
@@ -61,6 +61,8 @@ const (
 	WfInstanceIdLabelKey      = "workflows.argoproj.io/controller-instanceid"
 	WfInstanceId              = "activemonitor-workflows"
 	PodGCOnPodCompletion      = "OnPodCompletion"
+	WfManagedByLabelKey       = "workflows.argoproj.io/managed-by"
+	WfManagedByValue          = "active-monitor"
 )
 
 var (
@@ -268,105 +270,153 @@ func (r *HealthCheckReconciler) createRBACForWorkflow(log logr.Logger, hc *activ
 	}
 
 	if workFlowType != remedy {
-		servacc, err := r.createServiceAccount(r.kubeclient, hcSa, wfNamespace)
+		servacc, created, err := r.createServiceAccount(r.kubeclient, hcSa, wfNamespace)
 		if err != nil {
 			log.Error(err, "Error creating ServiceAccount for the workflow")
 			r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Error creating ServiceAccount for the workflow")
 			return err
 		}
-		log.Info("Successfully Created", "ServiceAccount", servacc)
-		r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created ServiceAccount")
+		if created {
+			log.Info("Successfully Created", "ServiceAccount", servacc)
+			r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created ServiceAccount")
+		} else {
+			log.Info("Found existing", "ServiceAccount", servacc)
+			r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Existing service account found")
+		}
 	} else {
-		servacc1, err := r.createServiceAccount(r.kubeclient, remedySa, wfRemedyNamespace)
+		servacc1, created, err := r.createServiceAccount(r.kubeclient, remedySa, wfRemedyNamespace)
 		if err != nil {
 			log.Error(err, "Error creating ServiceAccount for the workflow")
 			r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Error creating ServiceAccount for the workflow")
 			return err
 		}
-		log.Info("Successfully Created", "ServiceAccount", servacc1)
-		r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created ServiceAccount")
+		if created {
+			log.Info("Successfully Created", "ServiceAccount", servacc1)
+			r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created ServiceAccount")
+		} else {
+			log.Info("Found existing", "ServiceAccount", servacc1)
+			r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Existing ServiceAccount found")
+		}
+
 	}
 	if level == healthCheckClusterLevel {
 
 		if workFlowType != remedy {
-			clusrole, err := r.createClusterRole(r.kubeclient, amclusterRole)
+			clusrole, created, err := r.createClusterRole(r.kubeclient, amclusterRole)
 			if err != nil {
 				log.Error(err, "Error creating ClusterRole for the healthcheck workflow")
 				r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Error creating ClusterRole for the healthcheck workflow")
 				return err
 			}
-			log.Info("Successfully Created", "ClusterRole", clusrole)
-			r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created clusterrole")
+			if created {
+				log.Info("Successfully Created", "ClusterRole", clusrole)
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created clusterrole")
+			} else {
+				log.Info("Found existing", "ClusterRole", clusrole)
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Existing clusterrole found")
+			}
 
-			crb, err := r.createClusterRoleBinding(r.kubeclient, amclusterRoleBinding, amclusterRole, hcSa, wfNamespace)
+			crb, created, err := r.createClusterRoleBinding(r.kubeclient, amclusterRoleBinding, amclusterRole, hcSa, wfNamespace)
 			if err != nil {
 				log.Error(err, "Error creating ClusterRoleBinding for the workflow")
 				r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Error creating ClusterRoleBinding for the workflow")
 				return err
 			}
-			log.Info("Successfully Created", "ClusterRoleBinding", crb)
-			r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created ClusterRoleBinding")
+			if created {
+				log.Info("Successfully Created", "ClusterRoleBinding", crb)
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created ClusterRoleBinding")
+			} else {
+				log.Info("Found existing", "ClusterRoleBinding", crb)
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Existing ClusterRoleBinding found")
+			}
 
 		} else {
-			clusrole1, err := r.createRemedyClusterRole(r.kubeclient, amclusterRemedyRole)
+			clusrole1, created, err := r.createRemedyClusterRole(r.kubeclient, amclusterRemedyRole)
 			if err != nil {
 				log.Error(err, "Error creating ClusterRole for the remedy workflow")
 				r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Error creating ClusterRole for the remedy workflow")
 				return err
 			}
-			log.Info("Successfully Created", "ClusterRole", clusrole1)
-			r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created ClusterRole")
-
-			crb1, err := r.createClusterRoleBinding(r.kubeclient, amclusterRoleRemedyBinding, amclusterRemedyRole, remedySa, wfRemedyNamespace)
+			if created {
+				log.Info("Successfully Created", "ClusterRole", clusrole1)
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created ClusterRole")
+			} else {
+				log.Info("Found existing", "ClusterRole", clusrole1)
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Existing ClusterRole found")
+			}
+			crb1, created, err := r.createClusterRoleBinding(r.kubeclient, amclusterRoleRemedyBinding, amclusterRemedyRole, remedySa, wfRemedyNamespace)
 			if err != nil {
 				log.Error(err, "Error creating ClusterRoleBinding for the workflow")
 				r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Error creating ClusterRoleBinding for the remedy workflow")
 				return err
 			}
-			log.Info("Successfully Created", "ClusterRoleBinding", crb1)
-			r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created ClusterRoleBinding")
+			if created {
+				log.Info("Successfully Created", "ClusterRoleBinding", crb1)
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created ClusterRoleBinding")
+			} else {
+				log.Info("Found existing", "ClusterRoleBinding", crb1)
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Existing ClusterRoleBinding found")
+			}
 
 		}
 
 	} else if level == healthCheckNamespaceLevel {
 
 		if workFlowType != remedy {
-			nsRole, err := r.createNameSpaceRole(r.kubeclient, amnsRole, wfNamespace)
+			nsRole, created, err := r.createNameSpaceRole(r.kubeclient, amnsRole, wfNamespace)
 			if err != nil {
 				log.Error(err, "Error creating NamespaceRole for the workflow")
 				r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Error creating NamespaceRole for the workflow")
 				return err
 			}
-			log.Info("Successfully Created", "NamespaceRole", nsRole)
-			r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created NamespaceRole")
-
-			nsrb, err := r.createNameSpaceRoleBinding(r.kubeclient, amnsRoleBinding, amnsRole, hcSa, wfNamespace)
+			if created {
+				log.Info("Successfully Created", "NamespaceRole", nsRole)
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created NamespaceRole")
+			} else {
+				log.Info("Found existing", "NamespaceRole", nsRole)
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Existing NamespaceRole found")
+			}
+			nsrb, created, err := r.createNameSpaceRoleBinding(r.kubeclient, amnsRoleBinding, amnsRole, hcSa, wfNamespace)
 			if err != nil {
 				log.Error(err, "Error creating NamespaceRoleBinding for the workflow")
 				r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Error creating NamespaceRoleBinding for the workflow")
 				return err
 			}
-			log.Info("Successfully Created", "NamespaceRoleBinding", nsrb)
-			r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created NamespaceRoleBinding")
+			if created {
+				log.Info("Successfully Created", "NamespaceRoleBinding", nsrb)
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created NamespaceRoleBinding")
+			} else {
+				log.Info("Found existing", "NamespaceRoleBinding", nsrb)
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Existing NamespaceRoleBinding found")
+			}
 
 		} else {
-			nsRole1, err := r.createRemedyNameSpaceRole(r.kubeclient, amnsRemedyRole, wfRemedyNamespace)
+			nsRole1, created, err := r.createRemedyNameSpaceRole(r.kubeclient, amnsRemedyRole, wfRemedyNamespace)
 			if err != nil {
 				log.Error(err, "Error creating NamespaceRole for the workflow")
 				r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Error creating NamespaceRole for the workflow")
 				return err
 			}
-			log.Info("Successfully Created", "NamespaceRole", nsRole1)
-			r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created NamespaceRole")
-
-			nsrb1, err := r.createNameSpaceRoleBinding(r.kubeclient, amnsRemedyRoleBinding, amnsRemedyRole, remedySa, wfRemedyNamespace)
+			if created {
+				log.Info("Successfully Created", "NamespaceRole", nsRole1)
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created NamespaceRole")
+			} else {
+				log.Info("Found existing", "NamespaceRole", nsRole1)
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Existing NamespaceRole found")
+			}
+			nsrb1, created, err := r.createNameSpaceRoleBinding(r.kubeclient, amnsRemedyRoleBinding, amnsRemedyRole, remedySa, wfRemedyNamespace)
 			if err != nil {
 				log.Error(err, "Error creating NamespaceRoleBinding for the workflow")
 				r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Error creating NamespaceRoleBinding for the workflow")
 				return err
 			}
-			log.Info("Successfully Created", "NamespaceRoleBinding", nsrb1)
-			r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created NamespaceRoleBinding")
+			if created {
+				log.Info("Successfully Created", "NamespaceRoleBinding", nsrb1)
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Created NamespaceRoleBinding")
+			} else {
+				log.Info("Found existing", "NamespaceRoleBinding", nsrb1)
+				r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Existing NamespaceRoleBinding found")
+			}
 
 		}
 
@@ -388,55 +438,60 @@ func (r *HealthCheckReconciler) deleteRBACForWorkflow(log logr.Logger, hc *activ
 
 	amnsRemedyRole := remedySa + "-ns-role"
 	amnsRemedyRoleBinding := remedySa + "-ns-role-binding"
-	err := r.DeleteServiceAccount(r.kubeclient, remedySa, wfRemedyNamespace)
+	deleted, err := r.DeleteServiceAccount(r.kubeclient, remedySa, wfRemedyNamespace)
 	if err != nil {
 		log.Error(err, "Error deleting ServiceAccount for the workflow")
 		r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Error deleting ServiceAccount for the workflow")
 		return err
 	}
-	log.Info("Successfully Deleted", "ServiceAccount", remedySa)
-	r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Deleted ServiceAccount")
-
+	if deleted {
+		log.Info("Successfully Deleted", "ServiceAccount", remedySa)
+		r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully Deleted ServiceAccount")
+	}
 	if level == "cluster" {
 
-		err = r.DeleteClusterRole(r.kubeclient, amclusterRemedyRole)
+		deleted, err = r.DeleteClusterRole(r.kubeclient, amclusterRemedyRole)
 		if err != nil {
 			log.Error(err, "Error deleting ClusterRole for the workflow")
 			r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Error deleting ClusterRole for the workflow")
 			return err
 		}
-		log.Info("Successfully Deleted", "ClusterRole", amclusterRemedyRole)
-		r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully deleted ClusterRole")
-
-		err = r.DeleteClusterRoleBinding(r.kubeclient, amclusterRoleRemedyBinding, amclusterRemedyRole, remedySa, wfRemedyNamespace)
+		if deleted {
+			log.Info("Successfully Deleted", "ClusterRole", amclusterRemedyRole)
+			r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully deleted ClusterRole")
+		}
+		deleted, err = r.DeleteClusterRoleBinding(r.kubeclient, amclusterRoleRemedyBinding, amclusterRemedyRole, remedySa, wfRemedyNamespace)
 		if err != nil {
 			log.Error(err, "Error deleting ClusterRoleBinding for the workflow")
 			r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Error creating ClusterRoleBinding for the workflow")
 			return err
 		}
-		log.Info("Successfully Deleted", "ClusterRoleBinding", amclusterRoleRemedyBinding)
-		r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully deleted ClusterRoleBinding")
-
+		if deleted {
+			log.Info("Successfully Deleted", "ClusterRoleBinding", amclusterRoleRemedyBinding)
+			r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully deleted ClusterRoleBinding")
+		}
 	} else if level == "namespace" {
 
-		err := r.DeleteNameSpaceRole(r.kubeclient, amnsRemedyRole, wfRemedyNamespace)
+		deleted, err := r.DeleteNameSpaceRole(r.kubeclient, amnsRemedyRole, wfRemedyNamespace)
 		if err != nil {
 			log.Error(err, "Error deleting NamespaceRole for the workflow")
 			r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Error deleting NamespaceRole for the workflow")
 			return err
 		}
-		log.Info("Successfully deleted", "NamespaceRole", amnsRemedyRole)
-		r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully deleted NamespaceRole")
-
-		err = r.DeleteNameSpaceRoleBinding(r.kubeclient, amnsRemedyRoleBinding, amnsRemedyRole, remedySa, wfRemedyNamespace)
+		if deleted {
+			log.Info("Successfully deleted", "NamespaceRole", amnsRemedyRole)
+			r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully deleted NamespaceRole")
+		}
+		deleted, err = r.DeleteNameSpaceRoleBinding(r.kubeclient, amnsRemedyRoleBinding, amnsRemedyRole, remedySa, wfRemedyNamespace)
 		if err != nil {
 			log.Error(err, "Error deleting NamespaceRoleBinding for the workflow")
 			r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "Error deleting NamespaceRole for the workflow")
 			return err
 		}
-		log.Info("Successfully Deleted", "NamespaceRoleBinding", amnsRemedyRoleBinding)
-		r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully deleted NamespaceRoleBinding")
-
+		if deleted {
+			log.Info("Successfully Deleted", "NamespaceRoleBinding", amnsRemedyRoleBinding)
+			r.Recorder.Event(hc, v1.EventTypeNormal, "Normal", "Successfully deleted NamespaceRoleBinding")
+		}
 	} else {
 		err := errors.New("level is not set")
 		r.Recorder.Event(hc, v1.EventTypeWarning, "Warning", "level is not set")
@@ -1023,11 +1078,11 @@ func (r *HealthCheckReconciler) parseRemedyWorkflowFromHealthcheck(log logr.Logg
 }
 
 // Create ServiceAccount
-func (r *HealthCheckReconciler) createServiceAccount(clientset kubernetes.Interface, name string, namespace string) (string, error) {
+func (r *HealthCheckReconciler) createServiceAccount(clientset kubernetes.Interface, name string, namespace string) (string, bool, error) {
 	sa, err := clientset.CoreV1().ServiceAccounts(namespace).Get(name, metav1.GetOptions{})
 	// If a service account already exists just re-use it
 	if err == nil {
-		return sa.Name, nil
+		return sa.Name, false, nil
 	}
 
 	sa = &v1.ServiceAccount{
@@ -1038,43 +1093,53 @@ func (r *HealthCheckReconciler) createServiceAccount(clientset kubernetes.Interf
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels: map[string]string{
+				WfManagedByLabelKey: WfManagedByValue,
+			},
 		},
 	}
 
 	sa, err = clientset.CoreV1().ServiceAccounts(namespace).Create(sa)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
-	return sa.Name, nil
+	return sa.Name, true, nil
 }
 
 //Delete a service Account
-func (r *HealthCheckReconciler) DeleteServiceAccount(clientset kubernetes.Interface, name string, namespace string) error {
-	_, err := clientset.CoreV1().ServiceAccounts(namespace).Get(name, metav1.GetOptions{})
+func (r *HealthCheckReconciler) DeleteServiceAccount(clientset kubernetes.Interface, name string, namespace string) (bool, error) {
+	sa, err := clientset.CoreV1().ServiceAccounts(namespace).Get(name, metav1.GetOptions{})
 	// If a service account already exists just re-use it
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	err = clientset.CoreV1().ServiceAccounts(namespace).Delete(name, &metav1.DeleteOptions{})
-	if err != nil {
-		return err
+	// Delete only if created by the workflow
+	if val, ok := sa.Labels[WfManagedByLabelKey]; ok && val == WfManagedByValue {
+		err = clientset.CoreV1().ServiceAccounts(namespace).Delete(name, &metav1.DeleteOptions{})
+		if err != nil {
+			return false, err
+		}
+		return true, nil
 	}
 
-	return nil
+	return false, nil
 }
 
 // create a ClusterRole
-func (r *HealthCheckReconciler) createClusterRole(clientset kubernetes.Interface, clusterrole string) (string, error) {
+func (r *HealthCheckReconciler) createClusterRole(clientset kubernetes.Interface, clusterrole string) (string, bool, error) {
 	clusrole, err := clientset.RbacV1().ClusterRoles().Get(clusterrole, metav1.GetOptions{})
 	// If a Cluster Role already exists just re-use it
 	if err == nil {
-		return clusrole.Name, nil
+		return clusrole.Name, false, nil
 	}
 	clusrole, err = clientset.RbacV1().ClusterRoles().Create(&rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterrole,
+			Labels: map[string]string{
+				WfManagedByLabelKey: WfManagedByValue,
+			},
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -1087,22 +1152,25 @@ func (r *HealthCheckReconciler) createClusterRole(clientset kubernetes.Interface
 	})
 
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
-	return clusrole.Name, nil
+	return clusrole.Name, true, nil
 }
 
 // create a ClusterRole
-func (r *HealthCheckReconciler) createRemedyClusterRole(clientset kubernetes.Interface, clusterrole string) (string, error) {
+func (r *HealthCheckReconciler) createRemedyClusterRole(clientset kubernetes.Interface, clusterrole string) (string, bool, error) {
 	clusrole, err := clientset.RbacV1().ClusterRoles().Get(clusterrole, metav1.GetOptions{})
 	// If a Cluster Role already exists just re-use it
 	if err == nil {
-		return clusrole.Name, nil
+		return clusrole.Name, false, nil
 	}
 	clusrole, err = clientset.RbacV1().ClusterRoles().Create(&rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterrole,
+			Labels: map[string]string{
+				WfManagedByLabelKey: WfManagedByValue,
+			},
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -1114,39 +1182,47 @@ func (r *HealthCheckReconciler) createRemedyClusterRole(clientset kubernetes.Int
 	})
 
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
-	return clusrole.Name, nil
+	return clusrole.Name, true, nil
 }
 
 // Delete a ClusterRole
-func (r *HealthCheckReconciler) DeleteClusterRole(clientset kubernetes.Interface, clusterrole string) error {
-	_, err := clientset.RbacV1().ClusterRoles().Get(clusterrole, metav1.GetOptions{})
+func (r *HealthCheckReconciler) DeleteClusterRole(clientset kubernetes.Interface, clusterrole string) (bool, error) {
+	cr, err := clientset.RbacV1().ClusterRoles().Get(clusterrole, metav1.GetOptions{})
 	// If a Cluster Role already exists just re-use it
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	err = clientset.RbacV1().ClusterRoles().Delete(clusterrole, &metav1.DeleteOptions{})
-	if err != nil {
-		return err
+	// Delete only if created by the workflow
+	if val, ok := cr.Labels[WfManagedByLabelKey]; ok && val == WfManagedByValue {
+		err = clientset.RbacV1().ClusterRoles().Delete(clusterrole, &metav1.DeleteOptions{})
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+
 	}
 
-	return nil
+	return false, nil
 }
 
 // Create NamespaceRole
-func (r *HealthCheckReconciler) createNameSpaceRole(clientset kubernetes.Interface, nsrole string, namespace string) (string, error) {
+func (r *HealthCheckReconciler) createNameSpaceRole(clientset kubernetes.Interface, nsrole string, namespace string) (string, bool, error) {
 	nsrole1, err := clientset.RbacV1().Roles(namespace).Get(nsrole, metav1.GetOptions{})
 	// If a Namespace Role already exists just re-use it
 	if err == nil {
-		return nsrole1.Name, nil
+		return nsrole1.Name, false, nil
 	}
 	nsrole1, err = clientset.RbacV1().Roles(namespace).Create(&rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nsrole,
 			Namespace: namespace,
+			Labels: map[string]string{
+				WfManagedByLabelKey: WfManagedByValue,
+			},
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -1157,23 +1233,26 @@ func (r *HealthCheckReconciler) createNameSpaceRole(clientset kubernetes.Interfa
 		},
 	})
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
-	return nsrole1.Name, nil
+	return nsrole1.Name, true, nil
 }
 
 // Create NamespaceRole
-func (r *HealthCheckReconciler) createRemedyNameSpaceRole(clientset kubernetes.Interface, nsrole string, namespace string) (string, error) {
+func (r *HealthCheckReconciler) createRemedyNameSpaceRole(clientset kubernetes.Interface, nsrole string, namespace string) (string, bool, error) {
 	nsrole1, err := clientset.RbacV1().Roles(namespace).Get(nsrole, metav1.GetOptions{})
 	// If a Namespace Role already exists just re-use it
 	if err == nil {
-		return nsrole1.Name, nil
+		return nsrole1.Name, false, nil
 	}
 	nsrole1, err = clientset.RbacV1().Roles(namespace).Create(&rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nsrole,
 			Namespace: namespace,
+			Labels: map[string]string{
+				WfManagedByLabelKey: WfManagedByValue,
+			},
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -1184,39 +1263,47 @@ func (r *HealthCheckReconciler) createRemedyNameSpaceRole(clientset kubernetes.I
 		},
 	})
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
-	return nsrole1.Name, nil
+	return nsrole1.Name, true, nil
 }
 
 // Delete NamespaceRole
-func (r *HealthCheckReconciler) DeleteNameSpaceRole(clientset kubernetes.Interface, nsrole string, namespace string) error {
+func (r *HealthCheckReconciler) DeleteNameSpaceRole(clientset kubernetes.Interface, nsrole string, namespace string) (bool, error) {
 	// Check if a Namespace Role already exists
-	_, err := clientset.RbacV1().Roles(namespace).Get(nsrole, metav1.GetOptions{})
+	nr, err := clientset.RbacV1().Roles(namespace).Get(nsrole, metav1.GetOptions{})
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	err = clientset.RbacV1().Roles(namespace).Delete(nsrole, &metav1.DeleteOptions{})
-	if err != nil {
-		return err
+	// Delete only if created by the workflow
+	if val, ok := nr.Labels[WfManagedByLabelKey]; ok && val == WfManagedByValue {
+		err = clientset.RbacV1().Roles(namespace).Delete(nsrole, &metav1.DeleteOptions{})
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+
 	}
 
-	return nil
+	return false, nil
 }
 
 // Create a NamespaceRoleBinding
-func (r *HealthCheckReconciler) createNameSpaceRoleBinding(clientset kubernetes.Interface, rolebinding string, nsrole string, serviceaccount string, namespace string) (string, error) {
+func (r *HealthCheckReconciler) createNameSpaceRoleBinding(clientset kubernetes.Interface, rolebinding string, nsrole string, serviceaccount string, namespace string) (string, bool, error) {
 	nsrb, err := clientset.RbacV1().RoleBindings(namespace).Get(rolebinding, metav1.GetOptions{})
 	// If a Namespace RoleBinding already exists just re-use it
 	if err == nil {
-		return nsrb.Name, nil
+		return nsrb.Name, false, nil
 	}
 	nsrb, err = clientset.RbacV1().RoleBindings(namespace).Create(&rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rolebinding,
 			Namespace: namespace,
+			Labels: map[string]string{
+				WfManagedByLabelKey: WfManagedByValue,
+			},
 		},
 		Subjects: []rbacv1.Subject{
 			{
@@ -1231,37 +1318,46 @@ func (r *HealthCheckReconciler) createNameSpaceRoleBinding(clientset kubernetes.
 		},
 	})
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
-	return nsrb.Name, nil
+	return nsrb.Name, true, nil
 }
 
 // Delete NamespaceRoleBinding
-func (r *HealthCheckReconciler) DeleteNameSpaceRoleBinding(clientset kubernetes.Interface, rolebinding string, nsrole string, serviceaccount string, namespace string) error {
+func (r *HealthCheckReconciler) DeleteNameSpaceRoleBinding(clientset kubernetes.Interface, rolebinding string, nsrole string, serviceaccount string, namespace string) (bool, error) {
 	// Check if a Namespace RoleBinding exists
-	_, err := clientset.RbacV1().RoleBindings(namespace).Get(rolebinding, metav1.GetOptions{})
+	nrb, err := clientset.RbacV1().RoleBindings(namespace).Get(rolebinding, metav1.GetOptions{})
 	if err != nil {
-		return err
-	}
-	err = clientset.RbacV1().RoleBindings(namespace).Delete(rolebinding, &metav1.DeleteOptions{})
-	if err != nil {
-		return err
+		return false, err
 	}
 
-	return nil
+	// Delete only if created by the workflow
+	if val, ok := nrb.Labels[WfManagedByLabelKey]; ok && val == WfManagedByValue {
+		err = clientset.RbacV1().RoleBindings(namespace).Delete(rolebinding, &metav1.DeleteOptions{})
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+
+	}
+
+	return false, nil
 }
 
 // Create a ClusterRoleBinding
-func (r *HealthCheckReconciler) createClusterRoleBinding(clientset kubernetes.Interface, clusterrolebinding string, clusterrole string, serviceaccount string, namespace string) (string, error) {
+func (r *HealthCheckReconciler) createClusterRoleBinding(clientset kubernetes.Interface, clusterrolebinding string, clusterrole string, serviceaccount string, namespace string) (string, bool, error) {
 	crb, err := clientset.RbacV1().ClusterRoleBindings().Get(clusterrolebinding, metav1.GetOptions{})
 	// If a Cluster RoleBinding already exists just re-use it
 	if err == nil {
-		return crb.Name, nil
+		return crb.Name, false, nil
 	}
 	crb, err = clientset.RbacV1().ClusterRoleBindings().Create(&rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterrolebinding,
+			Labels: map[string]string{
+				WfManagedByLabelKey: WfManagedByValue,
+			},
 		},
 		Subjects: []rbacv1.Subject{
 			{
@@ -1277,27 +1373,32 @@ func (r *HealthCheckReconciler) createClusterRoleBinding(clientset kubernetes.In
 		},
 	})
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
-	return crb.Name, nil
+	return crb.Name, true, nil
 
 }
 
 // Delete ClusterRoleBinding
-func (r *HealthCheckReconciler) DeleteClusterRoleBinding(clientset kubernetes.Interface, clusterrolebinding string, clusterrole string, serviceaccount string, namespace string) error {
+func (r *HealthCheckReconciler) DeleteClusterRoleBinding(clientset kubernetes.Interface, clusterrolebinding string, clusterrole string, serviceaccount string, namespace string) (bool, error) {
 	// Check if a Cluster RoleBinding exists
-	_, err := clientset.RbacV1().ClusterRoleBindings().Get(clusterrolebinding, metav1.GetOptions{})
+	crb, err := clientset.RbacV1().ClusterRoleBindings().Get(clusterrolebinding, metav1.GetOptions{})
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	err = clientset.RbacV1().ClusterRoleBindings().Delete(clusterrolebinding, &metav1.DeleteOptions{})
-	if err != nil {
-		return err
+	// Delete only if created by the workflow
+	if val, ok := crb.Labels[WfManagedByLabelKey]; ok && val == WfManagedByValue {
+		err = clientset.RbacV1().ClusterRoleBindings().Delete(clusterrolebinding, &metav1.DeleteOptions{})
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+
 	}
 
-	return nil
+	return false, nil
 
 }
 

--- a/controllers/healthcheck_controller.go
+++ b/controllers/healthcheck_controller.go
@@ -114,7 +114,7 @@ func NewHealthCheckReconciler(mgr manager.Manager, log logr.Logger, MaxParallel 
 
 // +kubebuilder:rbac:groups=activemonitor.keikoproj.io,resources=healthchecks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=activemonitor.keikoproj.io,resources=healthchecks/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=argoproj.io,resources=workflow;workflows;workflowtasksets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=argoproj.io,resources=workflow;workflows;workflowtasksets;workflowtaskresults,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile per kubebuilder v2 pattern
 func (r *HealthCheckReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/deploy/deploy-argo.yaml
+++ b/deploy/deploy-argo.yaml
@@ -166,6 +166,633 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: workflowtaskresults.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: WorkflowTaskResult
+    listKind: WorkflowTaskResultList
+    plural: workflowtaskresults
+    singular: workflowtaskresult
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            message:
+              type: string
+            metadata:
+              type: object
+            outputs:
+              properties:
+                artifacts:
+                  items:
+                    properties:
+                      archive:
+                        properties:
+                          none:
+                            type: object
+                          tar:
+                            properties:
+                              compressionLevel:
+                                format: int32
+                                type: integer
+                            type: object
+                          zip:
+                            type: object
+                        type: object
+                      archiveLogs:
+                        type: boolean
+                      artifactGC:
+                        properties:
+                          podMetadata:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          serviceAccountName:
+                            type: string
+                          strategy:
+                            enum:
+                              - ""
+                              - OnWorkflowCompletion
+                              - OnWorkflowDeletion
+                              - Never
+                            type: string
+                        type: object
+                      artifactory:
+                        properties:
+                          passwordSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          url:
+                            type: string
+                          usernameSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                        required:
+                          - url
+                        type: object
+                      azure:
+                        properties:
+                          accountKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          blob:
+                            type: string
+                          container:
+                            type: string
+                          endpoint:
+                            type: string
+                          useSDKCreds:
+                            type: boolean
+                        required:
+                          - blob
+                          - container
+                          - endpoint
+                        type: object
+                      deleted:
+                        type: boolean
+                      from:
+                        type: string
+                      fromExpression:
+                        type: string
+                      gcs:
+                        properties:
+                          bucket:
+                            type: string
+                          key:
+                            type: string
+                          serviceAccountKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                        required:
+                          - key
+                        type: object
+                      git:
+                        properties:
+                          branch:
+                            type: string
+                          depth:
+                            format: int64
+                            type: integer
+                          disableSubmodules:
+                            type: boolean
+                          fetch:
+                            items:
+                              type: string
+                            type: array
+                          insecureIgnoreHostKey:
+                            type: boolean
+                          passwordSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          repo:
+                            type: string
+                          revision:
+                            type: string
+                          singleBranch:
+                            type: boolean
+                          sshPrivateKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          usernameSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                        required:
+                          - repo
+                        type: object
+                      globalName:
+                        type: string
+                      hdfs:
+                        properties:
+                          addresses:
+                            items:
+                              type: string
+                            type: array
+                          force:
+                            type: boolean
+                          hdfsUser:
+                            type: string
+                          krbCCacheSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          krbConfigConfigMap:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          krbKeytabSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          krbRealm:
+                            type: string
+                          krbServicePrincipalName:
+                            type: string
+                          krbUsername:
+                            type: string
+                          path:
+                            type: string
+                        required:
+                          - path
+                        type: object
+                      http:
+                        properties:
+                          auth:
+                            properties:
+                              basicAuth:
+                                properties:
+                                  passwordSecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  usernameSecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                              clientCert:
+                                properties:
+                                  clientCertSecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  clientKeySecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                              oauth2:
+                                properties:
+                                  clientIDSecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  clientSecretSecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  endpointParams:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                        - key
+                                      type: object
+                                    type: array
+                                  scopes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  tokenURLSecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                            type: object
+                          headers:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                          url:
+                            type: string
+                        required:
+                          - url
+                        type: object
+                      mode:
+                        format: int32
+                        type: integer
+                      name:
+                        type: string
+                      optional:
+                        type: boolean
+                      oss:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          bucket:
+                            type: string
+                          createBucketIfNotPresent:
+                            type: boolean
+                          endpoint:
+                            type: string
+                          key:
+                            type: string
+                          lifecycleRule:
+                            properties:
+                              markDeletionAfterDays:
+                                format: int32
+                                type: integer
+                              markInfrequentAccessAfterDays:
+                                format: int32
+                                type: integer
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          securityToken:
+                            type: string
+                        required:
+                          - key
+                        type: object
+                      path:
+                        type: string
+                      raw:
+                        properties:
+                          data:
+                            type: string
+                        required:
+                          - data
+                        type: object
+                      recurseMode:
+                        type: boolean
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          bucket:
+                            type: string
+                          createBucketIfNotPresent:
+                            properties:
+                              objectLocking:
+                                type: boolean
+                            type: object
+                          encryptionOptions:
+                            properties:
+                              enableEncryption:
+                                type: boolean
+                              kmsEncryptionContext:
+                                type: string
+                              kmsKeyId:
+                                type: string
+                              serverSideCustomerKeySecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                            type: object
+                          endpoint:
+                            type: string
+                          insecure:
+                            type: boolean
+                          key:
+                            type: string
+                          region:
+                            type: string
+                          roleARN:
+                            type: string
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          useSDKCreds:
+                            type: boolean
+                        type: object
+                      subPath:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                exitCode:
+                  type: string
+                parameters:
+                  items:
+                    properties:
+                      default:
+                        type: string
+                      description:
+                        type: string
+                      enum:
+                        items:
+                          type: string
+                        type: array
+                      globalName:
+                        type: string
+                      name:
+                        type: string
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          configMapKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          default:
+                            type: string
+                          event:
+                            type: string
+                          expression:
+                            type: string
+                          jqFilter:
+                            type: string
+                          jsonPath:
+                            type: string
+                          parameter:
+                            type: string
+                          path:
+                            type: string
+                          supplied:
+                            type: object
+                        type: object
+                    required:
+                      - name
+                    type: object
+                  type: array
+                result:
+                  type: string
+              type: object
+            phase:
+              type: string
+            progress:
+              type: string
+          required:
+            - metadata
+          type: object
+      served: true
+      storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workflowtasksets.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: WorkflowTaskSet
+    listKind: WorkflowTaskSetList
+    plural: workflowtasksets
+    shortNames:
+      - wfts
+    singular: workflowtaskset
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-map-type: atomic
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-map-type: atomic
+              x-kubernetes-preserve-unknown-fields: true
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: workflowtemplates.argoproj.io
 spec:
   group: argoproj.io
@@ -247,6 +874,7 @@ rules:
       - clusterworkflowtemplates/finalizers
       - workflowtasksets
       - workflowtasksets/finalizers
+      - workflowtaskresults
     verbs:
       - create
       - delete
@@ -287,6 +915,7 @@ rules:
       - clusterworkflowtemplates/finalizers
       - workflowtasksets
       - workflowtasksets/finalizers
+      - workflowtaskresults
     verbs:
       - create
       - delete
@@ -327,6 +956,7 @@ rules:
       - clusterworkflowtemplates/finalizers
       - workflowtasksets
       - workflowtasksets/finalizers
+      - workflowtaskresults
     verbs:
       - get
       - list
@@ -381,6 +1011,7 @@ rules:
       - workflows/finalizers
       - workflowtasksets
       - workflowtasksets/finalizers
+      - workflowtaskresults
     verbs:
       - get
       - list
@@ -477,6 +1108,7 @@ metadata:
 data:
   instanceID: activemonitor-workflows
   namespace: health
+  containerRuntimeExecutor: emissary
   workflowDefaults: |
     spec:
       ttlStrategy:
@@ -514,7 +1146,7 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoproj/argoexec:v3.2.6
+            - argoproj/argoexec:v3.3.9
           command:
             - workflow-controller
           env:
@@ -523,7 +1155,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          image: argoproj/workflow-controller:v3.2.6
+          image: argoproj/workflow-controller:v3.3.9
           livenessProbe:
             failureThreshold: 3
             httpGet:


### PR DESCRIPTION
Signed-off-by: awwwd <amitauddy94@gmail.com>

Fixes issue #122 

## Proposed Changes
  - Added logic for adding `workflows.argoproj.io/managed-by: active-monitor` labels to **RBAC** and **SA** resources created by active-monitor on the fly.
  - Added logic for deleting **RBAC** and **SA** resources only if `workflows.argoproj.io/managed-by: active-monitor` label is present. This way all the pre-configures **SA** or **RBAC** resources will not be deleted accidentally. 
  
## Testing Done
**Unit testing**
![image](https://user-images.githubusercontent.com/11169900/190894584-30e56b6e-20da-4a82-bdf7-8c553e01adc9.png)

**Testing with a sample CR**

Attaching labels to both **healthcheck** and **remedy** workflow RBAC and SA resources
![image](https://user-images.githubusercontent.com/11169900/190895399-f0f2997c-3309-406a-bc1f-600a1575b708.png)

Deleting **SA** and other **RBAC** when the label is attached
![image](https://user-images.githubusercontent.com/11169900/190895191-4f442135-5169-4050-a965-0e6b7d417ed4.png)

In case of **SA** and **RBAC** resources are **not present** on the system
![image](https://user-images.githubusercontent.com/11169900/190898617-71754bae-2450-420f-9a72-0b532d5f47b9.png)

In case of **SA** and **RBAC** resources already **exist** on the system
![image](https://user-images.githubusercontent.com/11169900/190898674-ecfc3bf3-21bc-4023-b129-e1c3e858e857.png)


