### PR TITLE
Update workflow-controller and argoexec to v3.4.4

### DIFF
--- a/deploy/deploy-argo.yaml
+++ b/deploy/deploy-argo.yaml
@@ -825,6 +825,48 @@ spec:
       served: true
       storage: true
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workflowartifactgctasks.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: WorkflowArtifactGCTask
+    listKind: WorkflowArtifactGCTaskList
+    plural: workflowartifactgctasks
+    shortNames:
+      - wfat
+    singular: workflowartifactgctask
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-map-type: atomic
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-map-type: atomic
+              x-kubernetes-preserve-unknown-fields: true
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -875,6 +917,7 @@ rules:
       - workflowtasksets
       - workflowtasksets/finalizers
       - workflowtaskresults
+      - workflowartifactgctasks
     verbs:
       - create
       - delete
@@ -916,6 +959,7 @@ rules:
       - workflowtasksets
       - workflowtasksets/finalizers
       - workflowtaskresults
+      - workflowartifactgctasks
     verbs:
       - create
       - delete
@@ -956,6 +1000,7 @@ rules:
       - clusterworkflowtemplates/finalizers
       - workflowtasksets
       - workflowtasksets/finalizers
+      - workflowartifactgctasks
     verbs:
       - get
       - list
@@ -1024,6 +1069,7 @@ rules:
       - workflowtasksets
       - workflowtasksets/finalizers
       - workflowtaskresults
+      - workflowartifactgctasks
     verbs:
       - get
       - list
@@ -1121,7 +1167,6 @@ metadata:
 data:
   instanceID: activemonitor-workflows
   namespace: health
-  containerRuntimeExecutor: emissary
   workflowDefaults: |
     spec:
       ttlStrategy:
@@ -1159,7 +1204,7 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoproj/argoexec:v3.3.9
+            - argoproj/argoexec:v3.4.4
           command:
             - workflow-controller
           env:
@@ -1168,7 +1213,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          image: argoproj/workflow-controller:v3.3.9
+          image: argoproj/workflow-controller:v3.4.4
           livenessProbe:
             failureThreshold: 3
             httpGet:


### PR DESCRIPTION
Signed-off-by: Sashank Agarwal <sashankagarwal97@gmail.com>

Fixes issue #132 

## Proposed Changes
  - Updates workflow-controller to v3.4.4
  - Updates argoexec to v3.4.4
  - Adds new CRD
  - Updates RBAC
  - Resolves multiple CVEs
  
## Testing Done
 
### Functional Test

```shell
Using cached envtest tools from /Users/sagarwal23/Desktop/Intuit/active-monitor/testbin
setting up env vars
ok      github.com/keikoproj/active-monitor/api/v1alpha1        10.510s coverage: 0.8% of statements
ok      github.com/keikoproj/active-monitor/controllers 35.445s coverage: 66.3% of statements
ok      github.com/keikoproj/active-monitor/metrics     4.038s  coverage: 81.8% of statements
?       github.com/keikoproj/active-monitor/store       [no test files]
```

### Logs

```shell
time="2022-12-07T09:43:59.357Z" level=info msg="Processing workflow" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:43:59.359Z" level=info msg="Task-result reconciliation" namespace=addon-active-monitor-ns numObjs=0 workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:43:59.359Z" level=warning msg="workflow uses legacy/insecure pod patch, see https://argoproj.github.io/argo-workflows/workflow-rbac/" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:43:59.359Z" level=info msg="node changed" namespace=addon-active-monitor-ns new.message= new.phase=Succeeded new.progress=0/1 nodeID=dns-healthcheck-workflow-mhw7n-3587066030 old.message= old.phase=Pending old.progress=0/1 workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:43:59.360Z" level=info msg="SG Outbound nodes of dns-healthcheck-workflow-mhw7n-1049159460 are [dns-healthcheck-workflow-mhw7n-1049159460]" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:43:59.360Z" level=info msg="SG Outbound nodes of dns-healthcheck-workflow-mhw7n-10348342 are [dns-healthcheck-workflow-mhw7n-10348342]" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:43:59.360Z" level=info msg="Step group node dns-healthcheck-workflow-mhw7n-3073224799 successful" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:43:59.360Z" level=info msg="node dns-healthcheck-workflow-mhw7n-3073224799 phase Running -> Succeeded" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n

time="2022-12-07T09:44:09.409Z" level=info msg="Processing workflow" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:44:09.410Z" level=info msg="Task-result reconciliation" namespace=addon-active-monitor-ns numObjs=0 workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:44:09.410Z" level=warning msg="workflow uses legacy/insecure pod patch, see https://argoproj.github.io/argo-workflows/workflow-rbac/" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:44:09.410Z" level=info msg="node changed" namespace=addon-active-monitor-ns new.message= new.phase=Succeeded new.progress=0/1 nodeID=dns-healthcheck-workflow-mhw7n-468232766 old.message= old.phase=Pending old.progress=0/1 workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:44:09.411Z" level=info msg="SG Outbound nodes of dns-healthcheck-workflow-mhw7n-1049159460 are [dns-healthcheck-workflow-mhw7n-1049159460]" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:44:09.411Z" level=info msg="SG Outbound nodes of dns-healthcheck-workflow-mhw7n-10348342 are [dns-healthcheck-workflow-mhw7n-10348342]" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:44:09.411Z" level=info msg="SG Outbound nodes of dns-healthcheck-workflow-mhw7n-3587066030 are [dns-healthcheck-workflow-mhw7n-3587066030]" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:44:09.412Z" level=info msg="Step group node dns-healthcheck-workflow-mhw7n-4214249986 successful" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:44:09.412Z" level=info msg="node dns-healthcheck-workflow-mhw7n-4214249986 phase Running -> Succeeded" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:44:09.412Z" level=info msg="node dns-healthcheck-workflow-mhw7n-4214249986 finished: 2022-12-07 09:44:09.412068433 +0000 UTC" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:44:09.412Z" level=info msg="Outbound nodes of dns-healthcheck-workflow-mhw7n-468232766 is [dns-healthcheck-workflow-mhw7n-468232766]" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:44:09.412Z" level=info msg="Outbound nodes of dns-healthcheck-workflow-mhw7n is [dns-healthcheck-workflow-mhw7n-468232766]" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:44:09.412Z" level=info msg="node dns-healthcheck-workflow-mhw7n phase Running -> Succeeded" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:44:09.412Z" level=info msg="node dns-healthcheck-workflow-mhw7n finished: 2022-12-07 09:44:09.41223674 +0000 UTC" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:44:09.412Z" level=info msg="Checking daemoned children of dns-healthcheck-workflow-mhw7n" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n
time="2022-12-07T09:44:09.412Z" level=info msg="TaskSet Reconciliation" namespace=addon-active-monitor-ns workflow=dns-healthcheck-workflow-mhw7n

time="2022-12-07T09:46:25.365Z" level=info msg="Create events 201"
time="2022-12-07T09:46:25.369Z" level=info msg="Create events 201"
time="2022-12-07T09:46:25.374Z" level=info msg="Create events 201"
time="2022-12-07T09:46:25.377Z" level=info msg="Create events 201"
time="2022-12-07T09:46:26.000Z" level=info msg="Deleting garbage collected workflow 'addon-active-monitor-ns/dns-hostnetwork-healthcheck-workflow-njkpg'"
time="2022-12-07T09:46:26.010Z" level=info msg="Delete workflows 200"
time="2022-12-07T09:46:26.010Z" level=info msg="Successfully deleted 'addon-active-monitor-ns/dns-hostnetwork-healthcheck-workflow-njkpg'"
```