### PR TITLE
bugfix: Fixes timer replacement without clearing the old one present

### DIFF
--- a/controllers/healthcheck_controller_test.go
+++ b/controllers/healthcheck_controller_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Active-Monitor Controller", func() {
 					return err
 				}
 
-				if instance.Status.StartedAt != nil {
+				if instance.Status.StartedAt != nil && instance.Status.SuccessCount+instance.Status.FailedCount >= 3 {
 					return nil
 				}
 				return fmt.Errorf("HealthCheck is not valid")


### PR DESCRIPTION
Fixes issue #??
#140 

## Proposed Changes
  - Add a Timer Stop before replacing the old timer with the rescheduled one.
  
## Testing Done
  - No increase seen even after days  
![image](https://user-images.githubusercontent.com/17066394/223030534-19348989-b07e-4041-9543-a14927fb9d50.png)

  - Unit tests
```shell
fetching envtest tools@1.19.2 (into '/Users/rkilingar/projects/active-monitor/testbin')
tar: Failed to set default locale
x bin/
x bin/etcd
x bin/kubectl
x bin/kube-apiserver
setting up env vars
ok      github.com/keikoproj/active-monitor/api/v1alpha1        17.629s coverage: 0.8% of statements
ok      github.com/keikoproj/active-monitor/controllers 42.703s coverage: 66.5% of statements
ok      github.com/keikoproj/active-monitor/metrics     2.106s  coverage: 81.8% of statements
?       github.com/keikoproj/active-monitor/store       [no test files]
```