### PR TITLE
chore: Prepare for release version v0.11.1

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ jobs:
   push:
     name: push
     if: github.repository_owner == 'keikoproj'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -10,7 +10,7 @@ jobs:
   unit-test:
     if: github.repository_owner == 'keikoproj'
     name: unit-test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -33,6 +33,6 @@ jobs:
           make test
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
-          file: ./coverage.txt
+          files: ./coverage.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 Bleeding-edge development, not yet released
 
+## [0.11.1] - 2023-03-06
+## Fixed
+- bugfix: Fixes timer replacement without clearing the old one present - #141
+
 ## [0.11.0] - 2022-12-07
 ## Updated
 - Update workflow-controller and argoexec version to v3.4.4 - #132
@@ -86,7 +90,8 @@ Bleeding-edge development, not yet released
 ### Added
 - Initial commit of project
 
-[Unreleased]: https://github.com/keikoproj/active-monitor/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/keikoproj/active-monitor/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/keikoproj/active-monitor/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/keikoproj/active-monitor/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/keikoproj/active-monitor/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/keikoproj/active-monitor/compare/v0.8.0...v0.9.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PR](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)][GithubPrsUrl]
 [![slack](https://img.shields.io/badge/slack-join%20the%20conversation-ff69b4.svg)][SlackUrl]
 
-![version](https://img.shields.io/badge/version-0.11.0-blue.svg?cacheSeconds=2592000)
+![version](https://img.shields.io/badge/version-0.11.1-blue.svg?cacheSeconds=2592000)
 [![Build Status][BuildStatusImg]][BuildMasterUrl]
 [![codecov][CodecovImg]][CodecovUrl]
 [![Go Report Card][GoReportImg]][GoReportUrl]


### PR DESCRIPTION
Fixes issue #142 

## Fixed
- bugfix: Fixes timer replacement without clearing the old one present - #141