### PR TITLE
feat: enable multi-architecture container image builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 Bleeding-edge development, not yet released
 
+## [0.11.2] - 2023-04-05
+## Updated
+- feat: enable multi-architecture container image builds - #144
+
 ## [0.11.1] - 2023-03-06
 ## Fixed
 - bugfix: Fixes timer replacement without clearing the old one present - #141
@@ -90,7 +94,8 @@ Bleeding-edge development, not yet released
 ### Added
 - Initial commit of project
 
-[Unreleased]: https://github.com/keikoproj/active-monitor/compare/v0.11.1...HEAD
+[Unreleased]: https://github.com/keikoproj/active-monitor/compare/v0.11.2...HEAD
+[0.11.2]: https://github.com/keikoproj/active-monitor/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/keikoproj/active-monitor/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/keikoproj/active-monitor/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/keikoproj/active-monitor/compare/v0.9.0...v0.10.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Build the manager binary
 FROM golang:1.18 as builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -17,7 +20,7 @@ COPY metrics/ metrics/
 COPY store/ store/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o active-monitor-controller main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o active-monitor-controller main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PR](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)][GithubPrsUrl]
 [![slack](https://img.shields.io/badge/slack-join%20the%20conversation-ff69b4.svg)][SlackUrl]
 
-![version](https://img.shields.io/badge/version-0.11.1-blue.svg?cacheSeconds=2592000)
+![version](https://img.shields.io/badge/version-0.11.2-blue.svg?cacheSeconds=2592000)
 [![Build Status][BuildStatusImg]][BuildMasterUrl]
 [![codecov][CodecovImg]][CodecovUrl]
 [![Go Report Card][GoReportImg]][GoReportUrl]


### PR DESCRIPTION
## Proposed Changes
  - Currently the pipeline already supports multi-arch docker image builds(https://github.com/keikoproj/active-monitor/blob/master/.github/workflows/push.yml#L51)
  - Removes hardcoded `GOOS=linux GOARCH=amd64` inside `Dockerfile` to fetch the default ones: [Reference](https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope)
  
## Testing Done
  - image build:
    - amd64:
    ```shell
    docker history docker.io/keikoproj/active-monitor:0.11.2
    IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
    f503baf7467b   20 minutes ago   ENTRYPOINT ["/active-monitor-controller"]       0B        buildkit.dockerfile.v0
    <missing>      20 minutes ago   COPY /workspace/active-monitor-controller . …   39.4MB    buildkit.dockerfile.v0
    <missing>      20 minutes ago   WORKDIR /                                       0B        buildkit.dockerfile.v0
    <missing>      292 years ago                                                    219kB     
    <missing>      292 years ago                                                    346B      
    <missing>      292 years ago                                                    497B      
    <missing>      292 years ago                                                    0B        
    <missing>      292 years ago                                                    64B       
    <missing>      292 years ago                                                    149B      
    <missing>      292 years ago                                                    1.93MB    
    <missing>      292 years ago                                                    29.4kB    
    <missing>      292 years ago                                                    270kB 
    ```


    - arm64:
    ```shell
    docker history docker.io/keikoproj/active-monitor:0.11.2
    IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
    e3101ad0326e   4 minutes ago   ENTRYPOINT ["/active-monitor-controller"]       0B        buildkit.dockerfile.v0
    <missing>      4 minutes ago   COPY /workspace/active-monitor-controller . …   38.4MB    buildkit.dockerfile.v0
    <missing>      4 minutes ago   WORKDIR /                                       0B        buildkit.dockerfile.v0
    <missing>      292 years ago                                                   219kB     
    <missing>      292 years ago                                                   346B      
    <missing>      292 years ago                                                   497B      
    <missing>      292 years ago                                                   0B        
    <missing>      292 years ago                                                   64B       
    <missing>      292 years ago                                                   149B      
    <missing>      292 years ago                                                   1.93MB    
    <missing>      292 years ago                                                   29.4kB    
    <missing>      292 years ago                                                   270kB
    ```