### PR TITLE
Allow customizable backoff factor and backoff max

### DIFF
--- a/api/v1alpha1/healthcheck_types.go
+++ b/api/v1alpha1/healthcheck_types.go
@@ -37,6 +37,7 @@ type HealthCheckSpec struct {
 	RemedyWorkflow      RemedyWorkflow `json:"remedyworkflow,omitempty"`
 	BackoffFactor       string         `json:"backoffFactor,omitempty"`
 	BackoffMax          int            `json:"backoffMax,omitempty"`
+	BackoffMin          int            `json:"backoffMin,omitempty"`
 	RemedyRunsLimit     int            `json:"remedyRunsLimit,omitempty"`
 	RemedyResetInterval int            `json:"remedyResetInterval,omitempty"`
 }

--- a/api/v1alpha1/healthcheck_types.go
+++ b/api/v1alpha1/healthcheck_types.go
@@ -16,8 +16,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -34,6 +35,8 @@ type HealthCheckSpec struct {
 	Level               string         `json:"level,omitempty"`    // defines if a workflow runs in a Namespace or Cluster level
 	Schedule            ScheduleSpec   `json:"schedule,omitempty"` // Schedule defines schedule rules to run HealthCheck
 	RemedyWorkflow      RemedyWorkflow `json:"remedyworkflow,omitempty"`
+	BackoffFactor       string         `json:"backoffFactor,omitempty"`
+	BackoffMax          int            `json:"backoffMax,omitempty"`
 	RemedyRunsLimit     int            `json:"remedyRunsLimit,omitempty"`
 	RemedyResetInterval int            `json:"remedyResetInterval,omitempty"`
 }

--- a/config/crd/bases/activemonitor.keikoproj.io_healthchecks.yaml
+++ b/config/crd/bases/activemonitor.keikoproj.io_healthchecks.yaml
@@ -58,6 +58,10 @@ spec:
               Either RepeatAfterSec or Schedule must be defined for the health check
               to run
             properties:
+              backoffFactor:
+                type: string
+              backoffMax:
+                type: integer
               description:
                 type: string
               level:

--- a/config/crd/bases/activemonitor.keikoproj.io_healthchecks.yaml
+++ b/config/crd/bases/activemonitor.keikoproj.io_healthchecks.yaml
@@ -62,6 +62,8 @@ spec:
                 type: string
               backoffMax:
                 type: integer
+              backoffMin:
+                type: integer
               description:
                 type: string
               level:

--- a/examples/bdd/inlineCustomBackoffTest.yaml
+++ b/examples/bdd/inlineCustomBackoffTest.yaml
@@ -1,0 +1,37 @@
+apiVersion: activemonitor.keikoproj.io/v1alpha1
+kind: HealthCheck
+metadata:
+  name: inline-hello-custom-retry
+  generateName: inline-hello-
+  namespace: health
+spec:
+  schedule:
+    cron: "@every 3s"
+  level: cluster
+  backoffFactor: "0.1"
+  backoffMin: 1
+  backoffMax: 2
+  workflow:
+    generateName: inline-hello-
+    resource:
+      namespace: health # workflow will be submitted in this ns
+      serviceAccount: activemonitor-controller-sa # workflow will be submitted using this acct
+      source:
+        inline: |
+          apiVersion: argoproj.io/v1alpha1
+          kind: Workflow
+          metadata:
+            labels:
+              workflows.argoproj.io/controller-instanceid: activemonitor-workflows
+            generateName: hello-world-
+          spec:
+            entrypoint: whalesay
+            templates:
+              -
+                container:
+                  args:
+                    - "hello world"
+                  command:
+                    - cowsay
+                  image: "docker/whalesay:latest"
+                name: whalesay

--- a/examples/bdd/inlineCustomBackoffTest.yaml
+++ b/examples/bdd/inlineCustomBackoffTest.yaml
@@ -13,6 +13,7 @@ spec:
   backoffMax: 2
   workflow:
     generateName: inline-hello-
+    windowtimeout: 1200
     resource:
       namespace: health # workflow will be submitted in this ns
       serviceAccount: activemonitor-controller-sa # workflow will be submitted using this acct

--- a/internal/controllers/healthcheck_controller.go
+++ b/internal/controllers/healthcheck_controller.go
@@ -506,13 +506,12 @@ func (r *HealthCheckReconciler) createSubmitRemedyWorkflow(ctx context.Context, 
 }
 
 func (r *HealthCheckReconciler) watchWorkflowReschedule(ctx context.Context, req ctrl.Request, log logr.Logger, wfNamespace, wfName string, hc *activemonitorv1alpha1.HealthCheck) error {
-	var now metav1.Time
+	var (
+		now              metav1.Time
+		maxTime, minTime time.Duration
+	)
 	then := metav1.Time{Time: time.Now()}
 	repeatAfterSec := hc.Spec.RepeatAfterSec
-	var (
-		maxTime time.Duration
-		minTime time.Duration
-	)
 	if hc.Spec.BackoffMax == 0 {
 		maxTime = time.Duration(hc.Spec.Workflow.Timeout/2) * time.Second
 		if maxTime <= 0 {


### PR DESCRIPTION
### Initial problem

We'd like to run tests with variable run-durations more frequently. This can be almost accomplished by setting a more rapid cron (e.g. 30s) along side a much longer `windowtimeout`. 

However, when using a larger `windowtimeout` w/ the previously hard-coded backoff factor, it can create a significant delay before the HC status is actually updated.

### Changes

* Allow for the max and min retry timeout to be customizable (to make it non exponential)
* Allow for the retry factor to be customizable
* Add clearer log indicating a workflow for a HC cannot be found
* Misc. code linting