### PR TITLE
Fix: When workflow already executed. After controller restart, healthcheck could never be scheduled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.so
 *.dylib
 testbin/*
+active-monitor-controller
 
 # Temporary or metadata files
 *.yaml-e

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -1,0 +1,6 @@
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:latest
+WORKDIR /
+COPY active-monitor-controller .
+ENTRYPOINT [ "/active-monitor-controller" ]

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ test: manifests generate fmt vet envtest ## Run tests.
 build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager cmd/main.go
 
+.PHONY: build-amd64
+build: manifests generate fmt vet ## Build manager binary.
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o active-monitor-controller cmd/main.go
+
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/main.go
@@ -82,6 +86,10 @@ run: manifests generate fmt vet ## Run a controller from your host.
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
 	$(CONTAINER_TOOL) build -t ${IMG} .
+
+.PHONY: docker-build-local
+docker-build: ## Build docker image with the manager.
+	$(CONTAINER_TOOL) build -t ${IMG} -f Dockerfile-local .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/internal/controllers/healthcheck_controller.go
+++ b/internal/controllers/healthcheck_controller.go
@@ -426,21 +426,21 @@ func (r *HealthCheckReconciler) createSubmitWorkflowHelper(ctx context.Context, 
 	return func() {
 		log.Info("Creating and Submitting Workflow...")
 
-		healthCheckNew := &activemonitorv1alpha1.HealthCheck{}
-		if err := r.Get(ctx, client.ObjectKey{Name: prevHealthCheck.Name, Namespace: prevHealthCheck.Namespace}, healthCheckNew); err != nil {
+		healthCheckInstance := &activemonitorv1alpha1.HealthCheck{}
+		if err := r.Get(ctx, client.ObjectKey{Name: prevHealthCheck.Name, Namespace: prevHealthCheck.Namespace}, healthCheckInstance); err != nil {
 			log.Error(err, "Error getting healthcheck resource")
 			return
 		}
 
-		wfName, err := r.createSubmitWorkflow(ctx, log, healthCheckNew)
+		wfName, err := r.createSubmitWorkflow(ctx, log, healthCheckInstance)
 		if err != nil {
 			log.Error(err, "Error creating or submitting workflow")
-			r.Recorder.Event(healthCheckNew, v1.EventTypeWarning, "Warning", "Error creating or submitting workflow")
+			r.Recorder.Event(healthCheckInstance, v1.EventTypeWarning, "Warning", "Error creating or submitting workflow")
 		}
-		err = r.watchWorkflowReschedule(ctx, ctrl.Request{}, log, wfNamespace, wfName, healthCheckNew)
+		err = r.watchWorkflowReschedule(ctx, ctrl.Request{}, log, wfNamespace, wfName, healthCheckInstance)
 		if err != nil {
 			log.Error(err, "Error watching or rescheduling workflow")
-			r.Recorder.Event(healthCheckNew, v1.EventTypeWarning, "Warning", "Error watching or rescheduling workflow")
+			r.Recorder.Event(healthCheckInstance, v1.EventTypeWarning, "Warning", "Error watching or rescheduling workflow")
 		}
 	}
 }

--- a/internal/controllers/healthcheck_controller_test.go
+++ b/internal/controllers/healthcheck_controller_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -38,8 +38,7 @@ var _ = Describe("Active-Monitor Controller", func() {
 	Describe("healthCheck CR can be reconciled at cluster level", func() {
 		var instance *activemonitorv1alpha1.HealthCheck
 		It("instance should be parsable", func() {
-			// healthCheckYaml, err := ioutil.ReadFile("../examples/inlineHello.yaml")
-			healthCheckYaml, err := ioutil.ReadFile("../../examples/bdd/inlineMemoryRemedyUnitTest.yaml")
+			healthCheckYaml, err := os.ReadFile("../../examples/bdd/inlineMemoryRemedyUnitTest.yaml")
 			Expect(err).ToNot(HaveOccurred())
 			instance, err = parseHealthCheckYaml(healthCheckYaml)
 			Expect(err).ToNot(HaveOccurred())
@@ -77,8 +76,8 @@ var _ = Describe("Active-Monitor Controller", func() {
 		var instance *activemonitorv1alpha1.HealthCheck
 
 		It("instance should be parsable", func() {
-			// healthCheckYaml, err := ioutil.ReadFile("../examples/inlineHello.yaml")
-			healthCheckYaml, err := ioutil.ReadFile("../../examples/bdd/inlineMemoryRemedyUnitTest_Namespace.yaml")
+			// healthCheckYaml, err := os.ReadFile("../examples/inlineHello.yaml")
+			healthCheckYaml, err := os.ReadFile("../../examples/bdd/inlineMemoryRemedyUnitTest_Namespace.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			instance, err = parseHealthCheckYaml(healthCheckYaml)
@@ -117,7 +116,7 @@ var _ = Describe("Active-Monitor Controller", func() {
 		var instance *activemonitorv1alpha1.HealthCheck
 
 		It("instance should be parsable", func() {
-			healthCheckYaml, err := ioutil.ReadFile("../../examples/bdd/inlineHelloTest.yaml")
+			healthCheckYaml, err := os.ReadFile("../../examples/bdd/inlineHelloTest.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			instance, err = parseHealthCheckYaml(healthCheckYaml)
@@ -156,7 +155,7 @@ var _ = Describe("Active-Monitor Controller", func() {
 		var instance *activemonitorv1alpha1.HealthCheck
 
 		It("instance should be parsable", func() {
-			healthCheckYaml, err := ioutil.ReadFile("../../examples/bdd/inlineCustomBackoffTest.yaml")
+			healthCheckYaml, err := os.ReadFile("../../examples/bdd/inlineCustomBackoffTest.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			instance, err = parseHealthCheckYaml(healthCheckYaml)

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -106,14 +106,15 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (&HealthCheckReconciler{
+	sharedCtrl = &HealthCheckReconciler{
 		Client:     k8sManager.GetClient(),
 		DynClient:  dynamic.NewForConfigOrDie(k8sManager.GetConfig()),
 		Recorder:   k8sManager.GetEventRecorderFor("HealthCheck"),
 		kubeclient: kubernetes.NewForConfigOrDie(k8sManager.GetConfig()),
 		Log:        log,
 		TimerLock:  sync.RWMutex{},
-	}).SetupWithManager(k8sManager)
+	}
+	err = sharedCtrl.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {


### PR DESCRIPTION
Fix: When workflow already executed. After reconcile and there's no reschedule handler, the healthcheck will never be executed.

## Proposed Changes
  - When reconcile event, if it is executed and there's scheduled timer in controller handler, then directly return.
  - When scheduled timer executed, it should fetch latest healthcheck spec and submit workflow. (in case workflow has any change)
  
## Testing Done
  - [x] Add unit-tests
  - [x] Deploy healthcheck, repeatAfterSec changed from 900s to 180s, the frequency updated properly.
  - [x] Deploy healthcheck, repeatAfterSec changed from 90 to 180s, the frequency updated properly.
  - [x] Restarted controller, it will reconcile all healthchecks, and since there's no scheduled handler populated, workflow will be submitted and reschedule timer. 