### PR TITLE
Upgrade to Go 1.25

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v6
         with:
-          go-version: 1.24
+          go-version: 1.25
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24 as builder
+FROM golang:1.25 as builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ $(KUSTOMIZE): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.20
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/keikoproj/active-monitor
 
-go 1.24.4
+go 1.25
 
 require (
 	github.com/argoproj/argo-workflows/v3 v3.6.19


### PR DESCRIPTION
## Summary

- Bumps Go version from 1.24 to 1.25 in `go.mod`, `Dockerfile`, and CI workflow
- Unpins `setup-envtest` from `@release-0.20` back to `@latest` (was pinned as a workaround for Go 1.24 incompatibility with setup-envtest)

Go 1.25 is a prerequisite for the Kubernetes 1.33 upgrade (#285), which requires controller-runtime v0.21.x.

Closes #284

## Test plan

- [x] `make all` builds successfully
- [x] `make test` passes all tests (all 3 test suites pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)