### PR TITLE
ci: remove linux/arm/v7 from multi-platform Docker build

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,8 +19,6 @@ jobs:
             runner: ubuntu-22.04
           - platform: linux/arm64
             runner: ubuntu-22.04-arm
-          - platform: linux/arm/v7
-            runner: ubuntu-22.04-arm
     steps:
       - name: Prepare
         run: |
@@ -35,12 +33,6 @@ jobs:
         with:
           install: true
           version: latest
-
-      - name: Set up QEMU
-        if: matrix.platform == 'linux/arm/v7'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm
 
       - name: Login to DockerHub
         if: github.ref_type == 'tag'


### PR DESCRIPTION
## Summary

- Remove `linux/arm/v7` from the build matrix
- Drop the QEMU setup step that was only needed for arm/v7 emulation

Remaining platforms: `linux/amd64` and `linux/arm64`.

## Test plan

- [ ] Confirm the two remaining build matrix jobs (`linux/amd64`, `linux/arm64`) pass
- [ ] On a release tag, verify the pushed manifest contains only `linux/amd64` and `linux/arm64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)