### PR TITLE
fix: add missing time.Second multiplier to BackoffMin

### DIFF
--- a/internal/controllers/healthcheck_controller.go
+++ b/internal/controllers/healthcheck_controller.go
@@ -509,13 +509,9 @@ func (r *HealthCheckReconciler) createSubmitRemedyWorkflow(ctx context.Context, 
 	return generatedName, nil
 }
 
-func (r *HealthCheckReconciler) watchWorkflowReschedule(ctx context.Context, req ctrl.Request, log logr.Logger, wfNamespace, wfName string, hc *activemonitorv1alpha1.HealthCheck) error {
-	var (
-		now              metav1.Time
-		maxTime, minTime time.Duration
-	)
-	then := metav1.Time{Time: time.Now()}
-	repeatAfterSec := hc.Spec.RepeatAfterSec
+// computeBackoffParams computes the inverse-exponential-backoff parameters
+// (maxTime, minTime, factor, timeout) from the HealthCheck spec.
+func (r *HealthCheckReconciler) computeBackoffParams(log logr.Logger, hc *activemonitorv1alpha1.HealthCheck) (maxTime, minTime time.Duration, factor float64, timeout time.Duration) {
 	if hc.Spec.BackoffMax == 0 {
 		maxTime = time.Duration(hc.Spec.Workflow.Timeout/2) * time.Second
 		if maxTime <= 0 {
@@ -530,10 +526,10 @@ func (r *HealthCheckReconciler) watchWorkflowReschedule(ctx context.Context, req
 			minTime = time.Second
 		}
 	} else {
-		minTime = time.Duration(hc.Spec.BackoffMin)
+		minTime = time.Duration(hc.Spec.BackoffMin) * time.Second
 	}
 
-	factor := 0.5
+	factor = 0.5
 
 	if hc.Spec.BackoffFactor != "" {
 		val, err := strconv.ParseFloat(hc.Spec.BackoffFactor, 64)
@@ -543,7 +539,15 @@ func (r *HealthCheckReconciler) watchWorkflowReschedule(ctx context.Context, req
 			factor = val
 		}
 	}
-	timeout := time.Duration(hc.Spec.Workflow.Timeout) * time.Second
+	timeout = time.Duration(hc.Spec.Workflow.Timeout) * time.Second
+	return
+}
+
+func (r *HealthCheckReconciler) watchWorkflowReschedule(ctx context.Context, req ctrl.Request, log logr.Logger, wfNamespace, wfName string, hc *activemonitorv1alpha1.HealthCheck) error {
+	var now metav1.Time
+	then := metav1.Time{Time: time.Now()}
+	repeatAfterSec := hc.Spec.RepeatAfterSec
+	maxTime, minTime, factor, timeout := r.computeBackoffParams(log, hc)
 	log.Info("IEB with timeout times are", "maxTime:", maxTime, "minTime:", minTime, "timeout:", timeout)
 	for ieTimer, err1 := iebackoff.NewIEBWithTimeout(maxTime, minTime, timeout, factor, time.Now()); ; err1 = ieTimer.Next() {
 		now = metav1.Time{Time: time.Now()}

--- a/internal/controllers/healthcheck_controller_unit_test.go
+++ b/internal/controllers/healthcheck_controller_unit_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	activemonitorv1alpha1 "github.com/keikoproj/active-monitor/api/v1alpha1"
@@ -291,4 +292,82 @@ func TestCreateRBACForWorkflow_SACollision_RemedyGetsSuffix(t *testing.T) {
 
 	assert.Equal(t, "shared-sa-remedy", hc.Spec.RemedyWorkflow.Resource.ServiceAccount,
 		"remedy SA should be renamed to avoid collision with health SA")
+}
+
+// --- computeBackoffParams ---
+
+func TestComputeBackoffParams_ExplicitValues(t *testing.T) {
+	r := newTestReconciler()
+	hc := newHC("backoff-explicit", "default")
+	hc.Spec.BackoffMin = 5
+	hc.Spec.BackoffMax = 10
+	hc.Spec.Workflow.Timeout = 60
+
+	maxTime, minTime, factor, timeout := r.computeBackoffParams(logr.Discard(), hc)
+
+	assert.Equal(t, 10*time.Second, maxTime, "maxTime should be BackoffMax in seconds")
+	assert.Equal(t, 5*time.Second, minTime, "minTime should be BackoffMin in seconds")
+	assert.Equal(t, 0.5, factor, "factor should default to 0.5")
+	assert.Equal(t, 60*time.Second, timeout, "timeout should be Workflow.Timeout in seconds")
+}
+
+func TestComputeBackoffParams_DefaultsFromTimeout(t *testing.T) {
+	r := newTestReconciler()
+	hc := newHC("backoff-defaults", "default")
+	hc.Spec.Workflow.Timeout = 120
+
+	maxTime, minTime, factor, timeout := r.computeBackoffParams(logr.Discard(), hc)
+
+	assert.Equal(t, 60*time.Second, maxTime, "maxTime should be Timeout/2")
+	assert.Equal(t, 2*time.Second, minTime, "minTime should be Timeout/60")
+	assert.Equal(t, 0.5, factor)
+	assert.Equal(t, 120*time.Second, timeout)
+}
+
+func TestComputeBackoffParams_MinClampedToOneSecond(t *testing.T) {
+	r := newTestReconciler()
+	hc := newHC("backoff-clamp", "default")
+	hc.Spec.Workflow.Timeout = 30 // 30/60 = 0, should clamp to 1s
+
+	maxTime, minTime, _, _ := r.computeBackoffParams(logr.Discard(), hc)
+
+	assert.Equal(t, 15*time.Second, maxTime, "maxTime should be Timeout/2")
+	assert.Equal(t, time.Second, minTime, "minTime should be clamped to 1s")
+}
+
+func TestComputeBackoffParams_MaxClampedToOneSecond(t *testing.T) {
+	r := newTestReconciler()
+	hc := newHC("backoff-max-clamp", "default")
+	hc.Spec.Workflow.Timeout = 0 // 0/2 = 0, should clamp to 1s
+
+	maxTime, minTime, _, _ := r.computeBackoffParams(logr.Discard(), hc)
+
+	assert.Equal(t, time.Second, maxTime, "maxTime should be clamped to 1s")
+	assert.Equal(t, time.Second, minTime, "minTime should be clamped to 1s")
+}
+
+func TestComputeBackoffParams_CustomFactor(t *testing.T) {
+	r := newTestReconciler()
+	hc := newHC("backoff-factor", "default")
+	hc.Spec.BackoffMin = 5
+	hc.Spec.BackoffMax = 10
+	hc.Spec.Workflow.Timeout = 60
+	hc.Spec.BackoffFactor = "0.8"
+
+	_, _, factor, _ := r.computeBackoffParams(logr.Discard(), hc)
+
+	assert.Equal(t, 0.8, factor, "factor should be parsed from BackoffFactor")
+}
+
+func TestComputeBackoffParams_InvalidFactor_DefaultsToHalf(t *testing.T) {
+	r := newTestReconciler()
+	hc := newHC("backoff-bad-factor", "default")
+	hc.Spec.BackoffMin = 5
+	hc.Spec.BackoffMax = 10
+	hc.Spec.Workflow.Timeout = 60
+	hc.Spec.BackoffFactor = "notanumber"
+
+	_, _, factor, _ := r.computeBackoffParams(logr.Discard(), hc)
+
+	assert.Equal(t, 0.5, factor, "factor should default to 0.5 on parse error")
 }


### PR DESCRIPTION
## Summary

- **Bug fix**: `BackoffMin` was cast to `time.Duration` without multiplying by `time.Second`, causing nanosecond-scale polling intervals when users set `spec.backoffMin` explicitly. This could overload the Kubernetes API server.
- **Refactor**: Extracted backoff computation into a testable `computeBackoffParams` helper method.
- **Tests**: Added 6 comprehensive unit tests covering explicit values, defaults from timeout, min/max clamping to 1s, custom factor, and invalid factor fallback.

Fixes #308

## Test plan

- [x] New unit tests pass: `go test ./internal/controllers/ -run TestComputeBackoffParams -v`
- [x] All existing unit tests pass: `go test ./internal/controllers/ -run 'Test' -v`
- [x] Full test suite (including envtests) passes: `go test ./... -count=1`
- [ ] Deploy to a test cluster and verify that a HealthCheck with explicit `backoffMin` polls at the correct second-scale interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)