### PR TITLE
controllers: delete RepeatTimersByName entry when HealthCheck is deleted

### DIFF
--- a/internal/controllers/healthcheck_controller.go
+++ b/internal/controllers/healthcheck_controller.go
@@ -176,12 +176,19 @@ func (r *HealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// if our healthcheck was deleted, this Reconcile method is invoked with an empty resource cache
 		// see: https://book.kubebuilder.io/cronjob-tutorial/controller-implementation.html#1-load-the-cronjob-by-name
 		log.Info("Healthcheck object not found for reconciliation, likely deleted")
-		// stop timer corresponding to next schedule run of workflow since parent healthcheck no longer exists
-		if r.GetTimerByName(req.NamespacedName.Name) != nil {
+		// Stop the pending timer for this HealthCheck and drop the map entry.
+		// Previously we only called Stop() and left the map entry behind,
+		// so RepeatTimersByName grew unbounded across the controller's
+		// lifetime as every deleted HealthCheck left a stopped-timer
+		// pointer pinned in memory (#314).
+		r.TimerLock.Lock()
+		if t, ok := r.RepeatTimersByName[req.NamespacedName.Name]; ok {
 			log.Info("Cancelling rescheduled workflow for this healthcheck due to deletion")
 			r.Recorder.Event(healthCheck, v1.EventTypeNormal, "Normal", "Cancelling workflow for this healthcheck due to deletion")
-			r.GetTimerByName(req.NamespacedName.Name).Stop()
+			t.Stop()
+			delete(r.RepeatTimersByName, req.NamespacedName.Name)
 		}
+		r.TimerLock.Unlock()
 		return ctrl.Result{}, ignoreNotFound(err)
 	}
 	return r.processOrRecoverHealthCheck(ctx, log, healthCheck)


### PR DESCRIPTION
## Summary

`RepeatTimersByName map[string]*time.Timer` is never cleaned up. When a HealthCheck is deleted the reconciler stops the pending timer at line 183 but leaves the map entry behind pointing to the stopped `*time.Timer`. Over the controller's lifetime the map grows monotonically in proportion to every HealthCheck that was ever created and then deleted — a small but unbounded leak that is noticeable in clusters with high HealthCheck churn.

## Fix

Take `TimerLock` for writing (the previous Stop path only used `RLock` via `GetTimerByName`), look up the entry, call `Stop()` and `delete()` in the same critical section. Same pattern as the suggested fix in the issue.

Fixes #314.

## Test

- `go build ./internal/controllers/...` green.
- `go vet ./internal/controllers/...` clean.
- `gofmt` clean.
- `go test ./internal/controllers/...` — the suite relies on an envtest control plane that fails in both master and this branch (`A BeforeSuite node failed`), so it's a pre-existing environment issue and not touched by this change.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
